### PR TITLE
 adding tiny sleep only

### DIFF
--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -113,6 +113,11 @@ class Article(Articles):
         self.open_configuration()
         if restore:
             self.base_selenium.click(element='general:configurations_archived') # open the archived tab
+            self.sleep_tiny()
         self.toggle_archive_field(field_name='unit', restore=restore)
+        self.sleep_tiny()
         self.toggle_archive_field(field_name='comment', restore=restore)
+        self.sleep_tiny()
         self.toggle_archive_field(field_name='related_article', restore=restore)
+        self.sleep_tiny()
+

--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -23,8 +23,8 @@ class Article(Articles):
             self.set_unit(self.article_unit)
             self.set_related_article()
             self.article_related_article = self.get_related_article()
-        
-        article_data={
+
+        article_data = {
             "name": self.article_name,
             "material_type": self.article_material_type
         }
@@ -101,23 +101,34 @@ class Article(Articles):
         for item in input_items:
             label = self.base_selenium.find_element_in_element(source=item, destination_element='general:label')
             if 'select' in label:
-                drop_down = self.base_selenium.find_element_in_element(source=item, destination_element='general:drop_down')
+                drop_down = self.base_selenium.find_element_in_element(source=item,
+                                                                       destination_element='general:drop_down')
                 self.base_selenium.select_item_from_drop_down(element_source=drop_down)
             if 'text' in label:
-                input_item = self.base_selenium.find_element_in_element(source=item, destination_element='general:input')
+                input_item = self.base_selenium.find_element_in_element(source=item,
+                                                                        destination_element='general:input')
                 # send text
 
     def archive_restore_optional_fields(self, restore=False):
         self.sleep_small()
-        self.info('+ Open article configuration')
+        self.info('Open article configuration')
         self.open_configuration()
         if restore:
-            self.base_selenium.click(element='general:configurations_archived') # open the archived tab
+            self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
             self.sleep_tiny()
         self.toggle_archive_field(field_name='unit', restore=restore)
-        self.sleep_tiny()
         self.toggle_archive_field(field_name='comment', restore=restore)
-        self.sleep_tiny()
         self.toggle_archive_field(field_name='related_article', restore=restore)
-        self.sleep_tiny()
 
+    def restore_ui(self,restore=True):
+        self.info('Open article configuration')
+        self.open_configuration()
+        self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
+        if self.base_selenium.check_element_is_exist('articles:unit_field_options'):
+            self.toggle_archive_field(field_name='unit', restore=restore)
+
+        if self.base_selenium.check_element_is_exist('articles:comment_field_options'):
+            self.toggle_archive_field(field_name='comment', restore=restore)
+
+        if self.base_selenium.check_element_is_exist('articles:related_article_field_options'):
+            self.toggle_archive_field(field_name='related_article', restore=restore)

--- a/ui_testing/pages/articles_page.py
+++ b/ui_testing/pages/articles_page.py
@@ -85,13 +85,13 @@ class Articles(BasePages):
 
     def toggle_archive_field(self, field_name, restore=False):
         self.base_selenium.click(element='articles:{}_field_options'.format(field_name))
-
         if restore:
             self.base_selenium.LOGGER.info('+ Restore field {}'.format(field_name))
             self.base_selenium.click(element='articles:{}_field_restore'.format(field_name))
         else:    
             self.base_selenium.LOGGER.info('+ Archive field {}'.format(field_name))
             self.base_selenium.click(element='articles:{}_field_archive'.format(field_name))
-            
         self.confirm_popup()
         self.sleep_tiny()
+
+

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -517,7 +517,6 @@ class ArticlesTestCases(BaseTest):
         New: Articles: Optional fields: User can hide/show any optional field in Edit/Create form
 
         LIMS:4123
-        :return:
         """
         # archive the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
@@ -591,6 +590,7 @@ class ArticlesTestCases(BaseTest):
     def test025_user_restore_any_optional_field_is_not_affecting_the_table(self):
         # archive then restore the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
+        self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
         self.article_page.archive_restore_optional_fields(restore=True)
 
@@ -610,6 +610,7 @@ class ArticlesTestCases(BaseTest):
     def test026_user_restore_any_optional_field_in_create_form(self):
         # archive then restore the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
+        self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
         self.article_page.archive_restore_optional_fields(restore=True)
 
@@ -671,7 +672,7 @@ class ArticlesTestCases(BaseTest):
         self.test_plan.get_test_plans_page()
         self.assertEqual(self.base_selenium.get_url(), '{}testPlans'.format(self.base_selenium.url))
 
-     def test029_hide_all_table_configurations(self):
+    def test029_hide_all_table_configurations(self):
         """
         Table configuration: Make sure that you can't hide all the fields from the table configuration
 


### PR DESCRIPTION
test Cases from 22-27 in test_articles file wasn't working accurate cause some of optional configuration was archived and not restored before tear down  so in next test case run field not found !

I just added tiny sleep to make sure each field is archived and restored.