### PR TITLE
LIMS-4123: Articles::hide/restore table configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,9 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test04_testunits.py:TestUnitsTestCases.test022_duplicate_test_unit
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test022_user_hide_any_optional_field_is_not_affecting_the_table --tc-file=config.ini
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test023_user_hide_any_optional_field_in_create_form_0_edit --tc-file=config.ini
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test023_user_hide_any_optional_field_in_create_form_1_create --tc-file=config.ini
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test024_user_restore_any_optional_field_is_not_affecting_the_table --tc-file=config.ini
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test025_user_restore_any_optional_field_in_create_form_0_edit --tc-file=config.ini
+  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test025_user_restore_any_optional_field_in_create_form_1_create --tc-file=config.ini

--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -145,7 +145,7 @@ class Article(Articles):
         self.sleep_medium()
 
     def archive_restore_optional_fields(self, restore=False):
-        self.sleep_small()
+        self.sleep_tiny()
         self.info('Open article configuration')
         self.open_configuration()
         if restore:

--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -145,9 +145,9 @@ class Article(Articles):
         self.sleep_medium()
 
     def archive_restore_optional_fields(self, restore=False):
-        self.sleep_tiny()
         self.info('Open article configuration')
         self.open_configuration()
+        self.sleep_tiny()
         if restore:
             self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
             self.sleep_tiny()

--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -150,7 +150,7 @@ class Article(Articles):
         self.sleep_tiny()
         if restore:
             self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
-            self.sleep_tiny()
+            self.sleep_small()
         self.toggle_archive_field(field_name='unit', restore=restore)
         self.toggle_archive_field(field_name='comment', restore=restore)
         self.toggle_archive_field(field_name='related_article', restore=restore)

--- a/ui_testing/pages/article_page.py
+++ b/ui_testing/pages/article_page.py
@@ -146,10 +146,25 @@ class Article(Articles):
 
     def archive_restore_optional_fields(self, restore=False):
         self.sleep_small()
-        self.info('+ Open article configuration')
+        self.info('Open article configuration')
         self.open_configuration()
         if restore:
-            self.base_selenium.click(element='general:configurations_archived') # open the archived tab
+            self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
+            self.sleep_tiny()
         self.toggle_archive_field(field_name='unit', restore=restore)
         self.toggle_archive_field(field_name='comment', restore=restore)
         self.toggle_archive_field(field_name='related_article', restore=restore)
+
+    def restore_ui(self, restore=True):
+        self.info('Open article configuration')
+        self.open_configuration()
+        self.base_selenium.click(element='general:configurations_archived')  # open the archived tab
+
+        if self.base_selenium.check_element_is_exist('articles:unit_field_options'):
+            self.toggle_archive_field(field_name='unit', restore=restore)
+
+        if self.base_selenium.check_element_is_exist('articles:comment_field_options'):
+            self.toggle_archive_field(field_name='comment', restore=restore)
+
+        if self.base_selenium.check_element_is_exist('articles:related_article_field_options'):
+            self.toggle_archive_field(field_name='related_article', restore=restore)

--- a/ui_testing/pages/articles_page.py
+++ b/ui_testing/pages/articles_page.py
@@ -85,13 +85,11 @@ class Articles(BasePages):
 
     def toggle_archive_field(self, field_name, restore=False):
         self.base_selenium.click(element='articles:{}_field_options'.format(field_name))
-
         if restore:
-            self.base_selenium.LOGGER.info('+ Restore field {}'.format(field_name))
+            self.base_selenium.LOGGER.info('Restore field {}'.format(field_name))
             self.base_selenium.click(element='articles:{}_field_restore'.format(field_name))
-        else:    
-            self.base_selenium.LOGGER.info('+ Archive field {}'.format(field_name))
+        else:
+            self.base_selenium.LOGGER.info('Archive field {}'.format(field_name))
             self.base_selenium.click(element='articles:{}_field_archive'.format(field_name))
-            
         self.confirm_popup()
         self.sleep_tiny()

--- a/ui_testing/pages/articles_page.py
+++ b/ui_testing/pages/articles_page.py
@@ -91,5 +91,5 @@ class Articles(BasePages):
         else:
             self.base_selenium.LOGGER.info('Archive field {}'.format(field_name))
             self.base_selenium.click(element='articles:{}_field_archive'.format(field_name))
-        self.confirm_popup()
         self.sleep_tiny()
+        self.confirm_popup()

--- a/ui_testing/pages/base_pages.py
+++ b/ui_testing/pages/base_pages.py
@@ -271,7 +271,7 @@ class BasePages:
     def open_configuration(self):
         self.base_selenium.click(element='general:right_menu')
         self.base_selenium.click(element='general:configurations')
-        self.sleep_medium()
+        self.sleep_small()
         
     def open_configure_table(self):
         self.base_selenium.LOGGER.info('open configure table')

--- a/ui_testing/testcases/base_test.py
+++ b/ui_testing/testcases/base_test.py
@@ -122,4 +122,7 @@ class BaseTest(TestCase):
         self.base_selenium.LOGGER.info(message)
 
     def set_authorization(self, auth):
+        if "Admin" in auth['role']:
+            del auth['role']
+            auth['roles'] = ["Admin"]
         self.base_selenium.set_local_storage('modeso-auth-token', auth)

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -591,18 +591,16 @@ class ArticlesTestCases(BaseTest):
         """
         # archive the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
-        self.article_page.sleep_tiny()
         # check if the fields still exist in the table
-        self.article_page.info('Open article table')
+        self.info('Open article table')
         self.article_page.get_articles_page()
-        article_headers = self.base_selenium.get_table_head_elements(
-            'general:table')
+        article_headers = self.base_selenium.get_table_head_elements('general:table')
         article_headers_text = [header.text for header in article_headers]
 
-        self.article_page.info('Check Comment field exist in the article table')
+        self.info('Check Comment field exist in the article table')
         self.assertIn('Comment', article_headers_text)
 
-        self.article_page.info('Check Unit field exist in the article table')
+        self.info('Check Unit field exist in the article table')
         self.assertIn('Unit', article_headers_text)
         # ignore related article since it shouldn't display in the table anyway
 
@@ -615,25 +613,25 @@ class ArticlesTestCases(BaseTest):
         """
         # archive the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
-        self.article_page.sleep_small()
+        self.article_page.sleep_tiny()
         # open edit/create page
         self.article_page.get_articles_page()
         if edit == "edit":
-            self.article_page.info('Open article edit page')
+            self.info('Open article edit page')
             self.article_page.open_edit_page(row=self.article_page.get_random_article_row())
         else:
-            self.article_page.info('Open article create page')
+            self.info('Open article create page')
             self.base_selenium.click(element='articles:new_article')
 
         self.article_page.sleep_tiny()
 
-        self.article_page.info('Check if Unit field exist in article page')
+        self.info('Check if Unit field exist in article page')
         self.assertFalse(self.base_selenium.check_element_is_exist('article:unit'))
 
-        self.article_page.info('Check if Comment field exist in article page')
+        self.info('Check if Comment field exist in article page')
         self.assertFalse(self.base_selenium.check_element_is_exist('article:comment'))
 
-        self.article_page.info('Check if Related article field exist in article page')
+        self.info('Check if Related article field exist in article page')
         self.assertFalse(self.base_selenium.check_element_is_exist('article:related_article'))
 
     def test024_user_restore_any_optional_field_is_not_affecting_the_table(self):
@@ -649,15 +647,15 @@ class ArticlesTestCases(BaseTest):
         self.article_page.archive_restore_optional_fields(restore=True)
 
         # check if the fields still exist in the table after restore
-        self.article_page.info('Open article table')
+        self.info('Open article table')
         self.article_page.get_articles_page()
         article_headers = self.base_selenium.get_table_head_elements('general:table')
         article_headers_text = [header.text for header in article_headers]
 
-        self.article_page.info('Check if Comment field exist in the table')
+        self.info('Check if Comment field exist in the table')
         self.assertIn('Comment', article_headers_text)
 
-        self.article_page.info('Check Unit field exist in the table')
+        self.info('Check Unit field exist in the table')
         self.assertIn('Unit', article_headers_text)
         # ignore related article since it shouldn't display in the table anyway
 
@@ -677,21 +675,21 @@ class ArticlesTestCases(BaseTest):
 
         if edit == "edit":
             # open edit page after restore
-            self.article_page.info('Open article edit page')
+            self.info('Open article edit page')
             self.article_page.open_edit_page(row=self.article_page.get_random_article_row())
         else:
             # open create page after restore
-            self.article_page.info('Open article create page')
+            self.info('Open article create page')
             self.base_selenium.click(element='articles:new_article')
-
         self.article_page.sleep_tiny()
-        self.article_page.info('Check if Unit field exist in article page')
+
+        self.info('Check if Unit field exist in article page')
         self.assertTrue(self.base_selenium.check_element_is_exist('article:unit'))
 
-        self.article_page.info('Check if Comment field exist in article page')
+        self.info('Check if Comment field exist in article page')
         self.assertTrue(self.base_selenium.check_element_is_exist('article:comment'))
 
-        self.article_page.info('Check if Related article field exist in article page')
+        self.info('Check if Related article field exist in article page')
         self.assertTrue(self.base_selenium.check_element_is_exist('article:related_article'))
 
     @parameterized.expand(['name', 'number', 'unit', 'created_at', 'material_type', 'changed_by'])

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -6,7 +6,7 @@ from api_testing.apis.article_api import ArticleAPI
 from parameterized import parameterized
 from unittest import skip
 import random, re
-
+import inspect
 
 class ArticlesTestCases(BaseTest):
     def setUp(self):
@@ -30,10 +30,17 @@ class ArticlesTestCases(BaseTest):
         }
 
     def tearDown(self):
-        if self.archived_optional_fields_flag:  # to restore the UI
+        # if test case of archive configurations we need to restore archived configuration fields before tear down
+        test_case_tag = self._testMethodName
+        if test_case_tag in ["test022_user_hide_any_optional_field_is_not_affecting_the_table",
+                             "test023_user_hide_any_optional_field_in_create_form_0_edit",
+                             "test023_user_hide_any_optional_field_in_create_form_1_create"
+                             "test024_user_restore_any_optional_field_is_not_affecting_the_table",
+                             "test025_user_restore_any_optional_field_in_create_form_0_edit",
+                             "test025_user_restore_any_optional_field_in_create_form_1_create"]:
+            self.article_page.info("check if any configuration field still archived before tear down")
             self.article_page.get_articles_page()
-            self.article_page.archive_restore_optional_fields(restore=True)
-            self.archived_optional_fields_flag = False
+            self.article_page.restore_ui()
 
         if self.default_filters_flags['name'] == True:
             self.article_page.toggle_default_filters(
@@ -579,164 +586,116 @@ class ArticlesTestCases(BaseTest):
     def test022_user_hide_any_optional_field_is_not_affecting_the_table(self):
         """
         New: Articles: Optional fields: User can hide/show any optional field in Edit/Create form
-
-        LIMS:4123
-        :return:
+        part 2
+        LIMS-4123
         """
         # archive the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
-        self.archived_optional_fields_flag = True  # to restore the UI in the tearDown
-
+        self.article_page.sleep_tiny()
         # check if the fields still exist in the table
-        self.article_page.info('+ Open article table')
+        self.article_page.info('Open article table')
         self.article_page.get_articles_page()
         article_headers = self.base_selenium.get_table_head_elements(
             'general:table')
         article_headers_text = [header.text for header in article_headers]
 
-        self.article_page.info('+ Check Comment field existance in the table')
+        self.article_page.info('Check Comment field exist in the article table')
         self.assertIn('Comment', article_headers_text)
 
-        self.article_page.info('+ Check Unit field existance in the table')
+        self.article_page.info('Check Unit field exist in the article table')
         self.assertIn('Unit', article_headers_text)
         # ignore related article since it shouldn't display in the table anyway
 
-    def test023_user_hide_any_optional_field_in_create_form(self):
+    @parameterized.expand(['edit', 'create'])
+    def test023_user_hide_any_optional_field_in_create_form(self, edit):
         """
         New: Articles: Optional fields: User can hide/show any optional field in Edit/Create form
-
-        LIMS:4123
-        :return:
+        part 1
+        LIMS-4123
         """
         # archive the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
-        self.archived_optional_fields_flag = True  # to restore the UI in the tearDown
-
-        # open create page
+        self.article_page.sleep_small()
+        # open edit/create page
         self.article_page.get_articles_page()
-        self.article_page.info('+ Open article create')
-        self.base_selenium.click(element='articles:new_article')
+        if edit == "edit":
+            self.article_page.info('Open article edit page')
+            self.article_page.open_edit_page(row=self.article_page.get_random_article_row())
+        else:
+            self.article_page.info('Open article create page')
+            self.base_selenium.click(element='articles:new_article')
+
         self.article_page.sleep_small()
 
-        self.article_page.info('+ Check Unit field existance in create page')
-        self.assertFalse(
-            self.base_selenium.check_element_is_exist('article:unit'))
+        self.article_page.info('Check if Unit field exist in article page')
+        self.assertFalse(self.base_selenium.check_element_is_exist('article:unit'))
 
-        self.article_page.info(
-            '+ Check Comment field existance in create page')
-        self.assertFalse(
-            self.base_selenium.check_element_is_exist('article:comment'))
+        self.article_page.info('Check if Comment field exist in article page')
+        self.assertFalse(self.base_selenium.check_element_is_exist('article:comment'))
 
-        self.article_page.info(
-            '+ Check Related article field existance in create page')
-        self.assertFalse(self.base_selenium.check_element_is_exist(
-            'article:related_article'))
+        self.article_page.info('Check if Related article field exist in article page')
+        self.assertFalse(self.base_selenium.check_element_is_exist('article:related_article'))
 
-    def test024_user_hide_any_optional_field_in_edit_form(self):
+    def test024_user_restore_any_optional_field_is_not_affecting_the_table(self):
         """
         New: Articles: Optional fields: User can hide/show any optional field in Edit/Create form
-
-        LIMS:4123
-        :return:
+        part 4
+        LIMS-4123
         """
-        # archive the optional fields
-        self.article_page.archive_restore_optional_fields(restore=False)
-        self.archived_optional_fields_flag = True  # to restore the UI in the tearDown
-
-        # open edit page
-        self.article_page.get_articles_page()
-        self.article_page.info('+ Open article edit')
-        self.article_page.get_articles_page()
-        self.article_page.open_edit_page(
-            row=self.article_page.get_random_article_row())
-
-        self.article_page.info('+ Check Unit field existance in edit page')
-        self.assertFalse(
-            self.base_selenium.check_element_is_exist('article:unit'))
-
-        self.article_page.info('+ Check Comment field existance in edit page')
-        self.assertFalse(
-            self.base_selenium.check_element_is_exist('article:comment'))
-
-        self.article_page.info(
-            '+ Check Related article field existance in edit page')
-        self.assertFalse(self.base_selenium.check_element_is_exist(
-            'article:related_article'))
-
-    def test025_user_restore_any_optional_field_is_not_affecting_the_table(self):
         # archive then restore the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
+        self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
         self.article_page.archive_restore_optional_fields(restore=True)
 
         # check if the fields still exist in the table after restore
-        self.article_page.info('+ Open article table')
+        self.article_page.info('Open article table')
         self.article_page.get_articles_page()
-        article_headers = self.base_selenium.get_table_head_elements(
-            'general:table')
+        article_headers = self.base_selenium.get_table_head_elements('general:table')
         article_headers_text = [header.text for header in article_headers]
 
-        self.article_page.info('+ Check Comment field existance in the table')
+        self.article_page.info('Check if Comment field exist in the table')
         self.assertIn('Comment', article_headers_text)
 
-        self.article_page.info('+ Check Unit field existance in the table')
+        self.article_page.info('Check Unit field exist in the table')
         self.assertIn('Unit', article_headers_text)
         # ignore related article since it shouldn't display in the table anyway
 
-    def test026_user_restore_any_optional_field_in_create_form(self):
+    @parameterized.expand(['edit', 'create'])
+    def test025_user_restore_any_optional_field_in_create_form(self, edit):
+        """
+        New: Articles: Optional fields: User can hide/show any optional field in Edit/Create form
+        part 3
+        LIMS-4123
+        """
         # archive then restore the optional fields
         self.article_page.archive_restore_optional_fields(restore=False)
+        self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
         self.article_page.archive_restore_optional_fields(restore=True)
-
-        # open create page after restore
         self.article_page.get_articles_page()
-        self.article_page.info('+ Open article create')
-        self.base_selenium.click(element='articles:new_article')
+
+        if edit == "edit":
+            # open edit page after restore
+            self.article_page.info('Open article edit page')
+            self.article_page.open_edit_page(row=self.article_page.get_random_article_row())
+        else:
+            # open create page after restore
+            self.article_page.info('Open article create page')
+            self.base_selenium.click(element='articles:new_article')
+
         self.article_page.sleep_small()
+        self.article_page.info('Check if Unit field exist in article page')
+        self.assertTrue(self.base_selenium.check_element_is_exist('article:unit'))
 
-        self.article_page.info('+ Check Unit field existance in create page')
-        self.assertTrue(
-            self.base_selenium.check_element_is_exist('article:unit'))
+        self.article_page.info('Check if Comment field exist in article page')
+        self.assertTrue(self.base_selenium.check_element_is_exist('article:comment'))
 
-        self.article_page.info(
-            '+ Check Comment field existance in create page')
-        self.assertTrue(
-            self.base_selenium.check_element_is_exist('article:comment'))
-
-        self.article_page.info(
-            '+ Check Related article field existance in create page')
-        self.assertTrue(self.base_selenium.check_element_is_exist(
-            'article:related_article'))
-
-    def test027_user_restore_any_optional_field_in_edit_form(self):
-        # archive then restore the optional fields
-        self.article_page.archive_restore_optional_fields(restore=False)
-        self.article_page.get_articles_page()
-        self.article_page.archive_restore_optional_fields(restore=True)
-
-        # open edit page after restore
-        self.article_page.get_articles_page()
-        self.article_page.info('+ Open article edit')
-        self.article_page.get_articles_page()
-        self.article_page.open_edit_page(
-            row=self.article_page.get_random_article_row())
-
-        self.article_page.info('+ Check Unit field existance in edit page')
-        self.assertTrue(
-            self.base_selenium.check_element_is_exist('article:unit'))
-
-        self.article_page.info('+ Check Comment field existance in edit page')
-        self.assertTrue(
-            self.base_selenium.check_element_is_exist('article:comment'))
-
-        self.article_page.info(
-            '+ Check Related article field existance in edit page')
-        self.assertTrue(self.base_selenium.check_element_is_exist(
-            'article:related_article'))
+        self.article_page.info('Check if Related article field exist in article page')
+        self.assertTrue(self.base_selenium.check_element_is_exist('article:related_article'))
 
     @parameterized.expand(['name', 'number', 'unit', 'created_at', 'material_type', 'changed_by'])
-    def test028_filter_article_by_any_field(self, filter_name):
+    def test026_filter_article_by_any_field(self, filter_name):
         """
         New: Article: Filter Approach: I can filter by any static field & and also from the default filter.
 
@@ -774,7 +733,7 @@ class ArticlesTestCases(BaseTest):
         self.assertIn(article[filter_name], result_article.text)
 
     @parameterized.expand(['name', 'number', 'unit', 'created_at', 'material_type', 'changed_by', 'test_plan'])
-    def test029_filter_article_by_any_default_filter(self, filter_name):
+    def test027_filter_article_by_any_default_filter(self, filter_name):
         """
         New: Article: Filter Approach: I can filter by any static field & and also from the default filter.
 
@@ -846,7 +805,7 @@ class ArticlesTestCases(BaseTest):
         self.test_plan.get_test_plans_page()
         self.assertEqual(self.base_selenium.get_url(), '{}testPlans'.format(self.base_selenium.url))
 
-    def test030_hide_all_table_configurations(self):
+    def test029_hide_all_table_configurations(self):
         """
         Table configuration: Make sure that you can't hide all the fields from the table configuration
 

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -34,7 +34,7 @@ class ArticlesTestCases(BaseTest):
         test_case_tag = self._testMethodName
         if test_case_tag in ["test022_user_hide_any_optional_field_is_not_affecting_the_table",
                              "test023_user_hide_any_optional_field_in_create_form_0_edit",
-                             "test023_user_hide_any_optional_field_in_create_form_1_create"
+                             "test023_user_hide_any_optional_field_in_create_form_1_create",
                              "test024_user_restore_any_optional_field_is_not_affecting_the_table",
                              "test025_user_restore_any_optional_field_in_create_form_0_edit",
                              "test025_user_restore_any_optional_field_in_create_form_1_create"]:
@@ -625,7 +625,7 @@ class ArticlesTestCases(BaseTest):
             self.article_page.info('Open article create page')
             self.base_selenium.click(element='articles:new_article')
 
-        self.article_page.sleep_small()
+        self.article_page.sleep_tiny()
 
         self.article_page.info('Check if Unit field exist in article page')
         self.assertFalse(self.base_selenium.check_element_is_exist('article:unit'))
@@ -684,7 +684,7 @@ class ArticlesTestCases(BaseTest):
             self.article_page.info('Open article create page')
             self.base_selenium.click(element='articles:new_article')
 
-        self.article_page.sleep_small()
+        self.article_page.sleep_tiny()
         self.article_page.info('Check if Unit field exist in article page')
         self.assertTrue(self.base_selenium.check_element_is_exist('article:unit'))
 

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -30,7 +30,8 @@ class ArticlesTestCases(BaseTest):
         }
 
     def tearDown(self):
-        # if test case of archive configurations we need to restore archived configuration fields before tear down
+        # if test case of archive/restore configurations we need to 
+        #restore archived configuration fields before tear down
         test_case_tag = self._testMethodName
         if test_case_tag in ["test022_user_hide_any_optional_field_is_not_affecting_the_table",
                              "test023_user_hide_any_optional_field_in_create_form_0_edit",

--- a/ui_testing/testcases/basic_tests/test02_articles.py
+++ b/ui_testing/testcases/basic_tests/test02_articles.py
@@ -617,6 +617,7 @@ class ArticlesTestCases(BaseTest):
         self.article_page.sleep_tiny()
         # open edit/create page
         self.article_page.get_articles_page()
+        self.article_page.sleep_tiny()
         if edit == "edit":
             self.info('Open article edit page')
             self.article_page.open_edit_page(row=self.article_page.get_random_article_row())
@@ -645,11 +646,13 @@ class ArticlesTestCases(BaseTest):
         self.article_page.archive_restore_optional_fields(restore=False)
         self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
+        self.article_page.sleep_tiny()
         self.article_page.archive_restore_optional_fields(restore=True)
 
         # check if the fields still exist in the table after restore
         self.info('Open article table')
         self.article_page.get_articles_page()
+        self.article_page.sleep_tiny()
         article_headers = self.base_selenium.get_table_head_elements('general:table')
         article_headers_text = [header.text for header in article_headers]
 
@@ -671,9 +674,10 @@ class ArticlesTestCases(BaseTest):
         self.article_page.archive_restore_optional_fields(restore=False)
         self.article_page.sleep_tiny()
         self.article_page.get_articles_page()
+        self.article_page.sleep_tiny()
         self.article_page.archive_restore_optional_fields(restore=True)
         self.article_page.get_articles_page()
-
+        self.article_page.sleep_tiny()
         if edit == "edit":
             # open edit page after restore
             self.info('Open article edit page')


### PR DESCRIPTION
**In the configuration section, In case I archive any optional field this field should be hidden from Edit/Create from and it should also found in the archive in table configuration.**