### PR TITLE
LIMS-6853: delete suborder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test033_Duplicate_main_order_and_cahange_materiel_type
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test033_delete_suborder

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -216,7 +216,7 @@ class OrdersAPIFactory(BaseAPI):
 
 class  OrdersAPI(OrdersAPIFactory):
     def get_order_with_multiple_sub_orders(self):
-        api, payload = self.get_all_orders()
+        api, payload = self.get_all_orders(limit=100)
         all_orders = api['orders']
         for order in all_orders:
             suborder = self.get_suborder_by_order_id(id=order['orderId'])[0]['orders']

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -215,7 +215,7 @@ class OrdersAPIFactory(BaseAPI):
         return payload
 
 class  OrdersAPI(OrdersAPIFactory):
-    def get_orders_with_multiple_sub_orders(self):
+    def get_order_with_multiple_sub_orders(self):
         api, payload = self.get_all_orders()
         all_orders = api['orders']
         for order in all_orders:

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -7,7 +7,7 @@ from api_testing.apis.base_api import api_factory
 import random
 
 
-class OrdersAPI(BaseAPI):
+class OrdersAPIFactory(BaseAPI):
     @api_factory('get')
     def get_all_orders(self, **kwargs):
         """
@@ -35,10 +35,10 @@ class OrdersAPI(BaseAPI):
         return api, {}
 
     @api_factory('get')
-    def get_suborder_by_order_id(self, id):
+    def get_suborder_by_order_id(self, id=0):
         """
         """
-        api = '{}{}{}'.format(self.url,self.END_POINTS['orders_api']['get_suborder'], str(id))
+        api = '{}{}{}'.format(self.url, self.END_POINTS['orders_api']['get_suborder'], str(id)+'&deleted=0')
         return api, {}
 
     @api_factory('post')
@@ -213,3 +213,13 @@ class OrdersAPI(BaseAPI):
 
         payload['materialTypeId'] = payload['materialType']['id']
         return payload
+
+class  OrdersAPI(OrdersAPIFactory):
+    def get_orders_with_multiple_sub_orders(self):
+        api, payload = self.get_all_orders()
+        all_orders = api['orders']
+        for order in all_orders:
+            suborder = self.get_suborder_by_order_id(id=order['orderId'])[0]['orders']
+            if len(suborder) > 1:
+                return order
+

--- a/ui_testing/elements.py
+++ b/ui_testing/elements.py
@@ -556,7 +556,11 @@ elements = {
         'mainorder_duplicate': {'method': 'id', 
                                 'value': 'main_table_duplicate'},
         'suborder_duplicate': {'method': 'id', 
-                               'value': 'child_table_duplicate'}
+                               'value': 'child_table_duplicate'},
+        'suborder_archive': {'method': 'id',
+                             'value': 'child_table_archive'},
+        'confirm_delete': {'method':'xpath',
+                           'value': '//h2[@id="swal2-title"]'}
     },
 
     'audit_trail': {
@@ -1025,7 +1029,8 @@ elements = {
             'value': 'table-with-add'
         },
         'analysis_page_table': {'method': 'class_name', 'value': 'm_accordion_7', 'order': 0},
-        'headers': {'method': 'id', 'value': 'headers'}
+        'headers': {'method': 'id', 'value': 'headers'},
+        'analysis_no_filter': {'method': 'id', 'value': 'nofield'}
     },
 
     'company_profile': {

--- a/ui_testing/elements.py
+++ b/ui_testing/elements.py
@@ -559,6 +559,8 @@ elements = {
                                'value': 'child_table_duplicate'},
         'suborder_archive': {'method': 'id',
                              'value': 'child_table_archive'},
+        'suborder_delete': {'method': 'id',
+                             'value': 'child_table_delete'},
         'confirm_delete': {'method':'xpath',
                            'value': '//h2[@id="swal2-title"]'}
     },

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -457,6 +457,8 @@ class Order(Orders):
             self.base_selenium.LOGGER.info('cancel archiving')
             self.base_selenium.click(element='articles:cancel_archive')
 
+
+
     def click_auto_fill(self):
         button = self.base_selenium.find_element_in_element(source_element='order:auto_fill_container',
                                                             destination_element='order:auto_fill')

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -488,7 +488,7 @@ class Order(Orders):
     def navigate_to_analysis_tab(self):
         self.base_selenium.scroll()
         self.base_selenium.click('orders:analysis_order_tab')
-        self.sleep_small()
+        self.wait_until_page_is_loaded()
 
     def set_material_type_of_first_suborder(self, material_type='', sub_order_index=0):
         suborder_table_rows = self.base_selenium.get_table_rows(

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -84,6 +84,13 @@ class Orders(BasePages):
         self.base_selenium.click(element='orders:create_copies')
         self.sleep_medium()
 
+    def archive_sub_order_from_active_table(self, index=0):
+        self.info('archive suborder from the order\'s active table')
+        child_table_records = self.result_table(element='general:table_child')
+        self.open_row_options(row=child_table_records[index])
+        self.base_selenium.click(element='orders:suborder_archive')
+        self.confirm_popup()
+
     def get_random_order(self):
         self.base_selenium.LOGGER.info(' + Get random order.')
         row = self.get_random_order_row()

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -91,6 +91,19 @@ class Orders(BasePages):
         self.base_selenium.click(element='orders:suborder_archive')
         self.confirm_popup()
 
+    def delete_sub_order(self, order_no, index=0, confirm_popup=True):
+        self.info('delete suborder of order No {}'.format(order_no))
+        import ipdb;ipdb.set_trace()
+        self.get_archived_items()
+        row = self.search(order_no)
+        self.click_check_box(row[0])
+        self.delete_selected_item()
+        if confirm_popup:
+            self.base_selenium.confirm_popup()
+        else:
+            self.info('Cancel the popup')
+            self.base_selenium.cancel()
+
     def get_random_order(self):
         self.base_selenium.LOGGER.info(' + Get random order.')
         row = self.get_random_order_row()

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -91,18 +91,28 @@ class Orders(BasePages):
         self.base_selenium.click(element='orders:suborder_archive')
         self.confirm_popup()
 
-    def delete_sub_order(self, order_no, index=0, confirm_popup=True):
-        self.info('delete suborder of order No {}'.format(order_no))
-        import ipdb;ipdb.set_trace()
+    def delete_sub_order(self, analysis_no, confirm_popup=True):
+        self.info('navigate to archived order table')
         self.get_archived_items()
-        row = self.search(order_no)
-        self.click_check_box(row[0])
-        self.delete_selected_item()
+        sub_orders = self.get_table_data(table_element='general:table_child')
+        child_table_records = self.result_table(element='general:table_child')
+        index = 0
+        if len(sub_orders) == 1:
+            index = 0
+        else:   # in case that order has more than one archived suborder
+            for suborder in sub_orders:
+                if suborder['Analysis No.'] == analysis_no:
+                    break
+                index = index+1
+        self.info("delete suborder with index {} and analysis_no {}".format(index, analysis_no))
+        self.open_row_options(row=child_table_records[index])
+        self.base_selenium.click(element='orders:suborder_delete')
+        self.confirm_popup()
         if confirm_popup:
-            self.base_selenium.confirm_popup()
+            self.confirm_popup()
         else:
             self.info('Cancel the popup')
-            self.base_selenium.cancel()
+            self.cancel()
 
     def get_random_order(self):
         self.base_selenium.LOGGER.info(' + Get random order.')

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -401,7 +401,7 @@ class OrdersTestCases(BaseTest):
             row=orders_analyess[0])
         self.assertEqual(
             orders_duplicate_data_after[0]['Analysis No.'], latest_order_data['Analysis No.'])
-        
+
     # will change that the duplicate many copies will be from the the child table not from the active table     
     def test012_duplicate_many_orders(self):
         """
@@ -732,13 +732,14 @@ class OrdersTestCases(BaseTest):
         # check if the shipment date changed or not
         if 'cancel' == save:
             self.base_selenium.LOGGER.info(
-                ' + Assert {} (current_shipment_date) != {} (new_shipment_date)'.format(new_shipment_date, saved_shipment_date))
+                ' + Assert {} (current_shipment_date) != {} (new_shipment_date)'.format(new_shipment_date,
+                                                                                        saved_shipment_date))
             self.assertNotEqual(saved_shipment_date, new_shipment_date)
         else:
             self.base_selenium.LOGGER.info(
-                ' + Assert {} (current_shipment_date) == {} (new_shipment_date)'.format(new_shipment_date, saved_shipment_date))
+                ' + Assert {} (current_shipment_date) == {} (new_shipment_date)'.format(new_shipment_date,
+                                                                                        saved_shipment_date))
             self.assertEqual(saved_shipment_date, new_shipment_date)
-
 
     # will continue with us
     def test018_validate_order_no_exists(self):
@@ -902,7 +903,7 @@ class OrdersTestCases(BaseTest):
             testunit_name = row_with_headers['Test Unit']
             self.base_selenium.LOGGER.info(" + Test unit : {}".format(testunit_name))
             self.assertIn(testunit_name, test_units_list)
-            
+
     def test022_create_existing_order_with_test_units_and_change_material_type(self):
         """
         New: Orders with test units: Create a new order from an existing order with
@@ -916,7 +917,7 @@ class OrdersTestCases(BaseTest):
         self.order_page.set_material_type(material_type='Subassembely')
         self.assertEqual(self.base_selenium.get_value(element='order:article'), None)
         self.assertEqual(self.base_selenium.get_value(element='order:test_unit'), None)
-        
+
         article = self.order_page.set_article()
         test_unit = self.order_page.set_test_unit()
         self.order_page.save(save_btn='order:save_btn', sleep=True)
@@ -1952,7 +1953,7 @@ class OrdersTestCases(BaseTest):
         LIMS-4255
         """
         article, article_data = self.article_api.create_article()
-        testunit_record = random.choice\
+        testunit_record = random.choice \
             (self.test_unit_api.get_all_test_units(filter='{"materialTypes":"all"}').json()['testUnits'])
 
         order = random.choice(self.orders_api.get_all_orders(limit=50)['orders'])
@@ -1987,10 +1988,10 @@ class OrdersTestCases(BaseTest):
         self.order_page.navigate_to_analysis_tab()
         analysis_count = self.single_analysis_page.get_analysis_count()
 
-        self.info('check analysis count\t'+ str (analysis_count) + "\tequals\t"+ str(analysis_count_before_adding + 1))
-        self.assertGreaterEqual(analysis_count, analysis_count_before_adding+1)
+        self.info('check analysis count\t' + str(analysis_count) + "\tequals\t" + str(analysis_count_before_adding + 1))
+        self.assertGreaterEqual(analysis_count, analysis_count_before_adding + 1)
 
-        analysis_record = self.single_analysis_page.open_accordion_for_analysis_index(analysis_count-1)
+        analysis_record = self.single_analysis_page.open_accordion_for_analysis_index(analysis_count - 1)
         testunit_in_analysis = self.single_analysis_page.get_testunits_in_analysis(source=analysis_record)
         self.assertEqual(len(testunit_in_analysis), 1)
         testunit_name = testunit_in_analysis[0]['']
@@ -2050,7 +2051,7 @@ class OrdersTestCases(BaseTest):
         year_value = self.order_page.get_current_year()[2:]
         formated_order_no = new_order_no + '-' + year_value
         self.info('newly generated order number = {}'.format(formated_order_no))
-        order = self.orders_api.get_all_orders(limit= 50)['orders'][1]
+        order = self.orders_api.get_all_orders(limit=50)['orders'][1]
         self.orders_page.get_order_edit_page_by_id(id=order['id'])
         self.order_page.set_no(no=formated_order_no)
         self.order_page.sleep_small()
@@ -2124,28 +2125,24 @@ class OrdersTestCases(BaseTest):
          Delete sub order Approach: In case I have main order with multiple sub orders ,
          make sure you can delete one of them
 
-        'LIMS-6853'
+         LIMS-6853
         """
-        # get the random main order data
-        order = self.orders_api.get_orders_with_multiple_sub_orders()
+        self.info('get random order with multiple suborders')
+        order = self.orders_api.get_order_with_multiple_sub_orders()
         self.order_page.search(order['orderNo'])
-        # archive first suborder
+        self.info('archive first suborder')
         suborder_data = self.order_page.get_child_table_data()[0]
         self.order_page.archive_sub_order_from_active_table()
-        # delete it
+        self.info('navigate to archived order table')
         self.order_page.get_archived_items()
-        row = self.order_page.search(order['orderNo'])
-        self.order_page.click_check_box(row[0])
-        self.order_page.delete_selected_item()
-        validation_result = self.base_selenium.get_text(element='orders:confirm_delete')
-        self.assertIn('Please note that the reports of this order will be deleted', validation_result)
-        self.order_page.confirm_popup()
-        # go to analysis page to make sure that analysis reated to that suborder is deleted
+        self.orders_page.delete_sub_order(order_no=order['orderNo'])
         self.info('Navigate to analysis page to make sure that analysis related to that suborder is deleted')
         self.order_page.get_orders_page()
+        self.order_page.search(order['orderNo'])
+        suborders_after_delete = self.order_page.get_child_table_data()
+        self.assertNotIn(suborder_data['Analysis No.'], suborders_after_delete)
         self.order_page.navigate_to_analysis_tab()
         self.order_page.sleep_small()
         self.analyses_page.apply_filter_scenario(filter_element='analysis_page:analysis_no_filter',
                                                  filter_text=suborder_data['Analysis No.'], field_type='text')
         self.assertEqual(len(self.order_page.result_table()), 1)
-

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2144,6 +2144,7 @@ class OrdersTestCases(BaseTest):
         self.info('Navigate to analysis page to make sure that analysis related to that suborder is deleted')
         self.order_page.get_orders_page()
         self.order_page.navigate_to_analysis_tab()
+        self.order_page.sleep_small()
         self.analyses_page.apply_filter_scenario(filter_element='analysis_page:analysis_no_filter',
                                                  filter_text=suborder_data['Analysis No.'], field_type='text')
         self.assertEqual(len(self.order_page.result_table()), 1)

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2122,7 +2122,7 @@ class OrdersTestCases(BaseTest):
 
     def test033_delete_suborder(self):
         """
-         Delete sub order Approach: In case I have main order with multiple sub orders ,
+         Delete sub order Approach: In case I have main order with multiple sub orders,
          make sure you can delete one of them
 
          LIMS-6853
@@ -2130,19 +2130,21 @@ class OrdersTestCases(BaseTest):
         self.info('get random order with multiple suborders')
         order = self.orders_api.get_order_with_multiple_sub_orders()
         self.order_page.search(order['orderNo'])
+
         self.info('archive first suborder')
         suborder_data = self.order_page.get_child_table_data()[0]
         self.order_page.archive_sub_order_from_active_table()
-        self.info('navigate to archived order table')
-        self.order_page.get_archived_items()
-        self.orders_page.delete_sub_order(order_no=order['orderNo'])
-        self.info('Navigate to analysis page to make sure that analysis related to that suborder is deleted')
+        self.orders_page.delete_sub_order(analysis_no=suborder_data['Analysis No.'])
+
+        self.info('Navigate to order page to make sure that suborder is deleted and main order still active')
         self.order_page.get_orders_page()
         self.order_page.search(order['orderNo'])
         suborders_after_delete = self.order_page.get_child_table_data()
         self.assertNotIn(suborder_data['Analysis No.'], suborders_after_delete)
+        self.assertGreater(len(suborder_data), 0)
+
+        self.info('Navigate to Analysis page to make sure that analysis related to deleted suborder not found')
         self.order_page.navigate_to_analysis_tab()
-        self.order_page.sleep_small()
         self.analyses_page.apply_filter_scenario(filter_element='analysis_page:analysis_no_filter',
                                                  filter_text=suborder_data['Analysis No.'], field_type='text')
         self.assertEqual(len(self.order_page.result_table()), 1)


### PR DESCRIPTION
**In case I have main order with multiple sub orders, make sure you can delete one of them**
```
➜  1lims-automation git:(LIMS-6853) ✗ nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test033_delete_suborder
2020-04-08 22:33:49.779 | INFO     | api_testing.apis.base_api:info:70 - Get authorized api session.
2020-04-08 22:33:50.582 | INFO     | api_testing.apis.base_api:info:70 - session ID : eyJhbGciOi .....
Delete sub order Approach: In case I have main order with multiple sub orders, ...      
2020-04-08 22:33:50.746 | INFO     | ui_testing.testcases.base_test:info:122 - Test case : test033_delete_suborder
2020-04-08 22:34:42.105 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:523 - wait until page is loaded
2020-04-08 22:34:42.105 | INFO     | ui_testing.pages.base_selenium:wait_until_element_is_not_displayed:187 - wait until element is not displayed
2020-04-08 22:34:43.315 | INFO     | ui_testing.testcases.base_test:info:122 - get random order with multiple suborders
2020-04-08 22:34:43.316 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders
2020-04-08 22:34:44.205 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:44.206 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=987&deleted=0
2020-04-08 22:34:44.602 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:44.602 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=985&deleted=0
2020-04-08 22:34:44.954 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:44.954 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=984&deleted=0
2020-04-08 22:34:45.345 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:45.345 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=983&deleted=0
2020-04-08 22:34:45.759 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:45.759 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=980&deleted=0
2020-04-08 22:34:46.110 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:46.110 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=979&deleted=0
2020-04-08 22:34:46.475 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:46.475 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=978&deleted=0
2020-04-08 22:34:46.884 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:46.884 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=977&deleted=0
2020-04-08 22:34:47.235 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:47.236 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=976&deleted=0
2020-04-08 22:34:47.605 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:47.606 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=975&deleted=0
2020-04-08 22:34:48.012 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:48.013 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=974&deleted=0
2020-04-08 22:34:48.356 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:48.356 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=973&deleted=0
2020-04-08 22:34:48.727 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:48.728 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=972&deleted=0
2020-04-08 22:34:49.137 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-08 22:34:49.765 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:00.043 | INFO     | ui_testing.testcases.base_test:info:122 - archive first suborder
2020-04-08 22:35:00.272 | INFO     | ui_testing.pages.base_pages:sleep_medium:47 -  Medium sleep.
2020-04-08 22:35:17.969 | INFO     | ui_testing.pages.base_pages:info:271 - archive suborder from the order's active table
2020-04-08 22:35:18.014 | INFO     | ui_testing.pages.base_pages:info:271 - open record options menu
2020-04-08 22:35:18.197 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-08 22:35:20.200 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:20.413 | INFO     | ui_testing.pages.base_pages:confirm_popup:73 - Confirming the popup
2020-04-08 22:35:20.461 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:30.722 | INFO     | ui_testing.pages.base_pages:info:271 - navigate to archived order table
2020-04-08 22:35:30.733 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:30.931 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:31.421 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-04-08 22:35:40.943 | INFO     | ui_testing.pages.base_pages:info:271 - delete suborder with index 1 and analysis_no 1'470-20
2020-04-08 22:35:40.944 | INFO     | ui_testing.pages.base_pages:info:271 - open record options menu
2020-04-08 22:35:41.109 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-08 22:35:43.111 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:43.330 | INFO     | ui_testing.pages.base_pages:confirm_popup:73 - Confirming the popup
2020-04-08 22:35:43.382 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:35:53.640 | INFO     | ui_testing.pages.base_pages:confirm_popup:73 - Confirming the popup
2020-04-08 22:35:53.671 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:36:03.900 | INFO     | ui_testing.testcases.base_test:info:122 - Navigate to order page to make sure that suborder is deleted and main order still active
2020-04-08 22:36:07.793 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:523 - wait until page is loaded
2020-04-08 22:36:07.794 | INFO     | ui_testing.pages.base_selenium:wait_until_element_is_not_displayed:187 - wait until element is not displayed
2020-04-08 22:36:11.449 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:36:21.988 | INFO     | ui_testing.pages.base_pages:sleep_medium:47 -  Medium sleep.
2020-04-08 22:36:37.995 | INFO     | ui_testing.testcases.base_test:info:122 - Navigate to Analysis page to make sure that analysis related to deleted suborder not found
2020-04-08 22:36:38.003 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:36:38.434 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:523 - wait until page is loaded
2020-04-08 22:36:38.434 | INFO     | ui_testing.pages.base_selenium:wait_until_element_is_not_displayed:187 - wait until element is not displayed
2020-04-08 22:36:41.270 | INFO     | ui_testing.pages.base_pages:open_filter_menu:82 -  Open Filter
2020-04-08 22:36:42.406 | INFO     | ui_testing.pages.base_selenium:wait_until_element_clickable:206 - wait until element clickable
2020-04-08 22:36:47.688 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-08 22:36:49.823 | INFO     | ui_testing.testcases.base_test:info:122 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 179.078s

OK


```