### PR TITLE
LIMS-6219: duplicate the main order then change the materiel type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,4 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test022_user_archive_optional_config_fields
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test023_user_restore_optional_config_fields
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test024_archive_optional_config_fields_effect__0_edit
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test024_archive_optional_config_fields_effect__1_create
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test025_restore_optional_config_fields_effect__0_edit
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test025_restore_optional_config_fields_effect__1_create
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING --tc-file=config.ini ui_testing/testcases/basic_tests/test02_articles.py:ArticlesTestCases.test026_archive_optional_config_fields_does_not_effect_table
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test033_Duplicate_main_order_and_cahange_materiel_type

--- a/api_testing/apis/test_plan_api.py
+++ b/api_testing/apis/test_plan_api.py
@@ -168,7 +168,7 @@ class TestPlanAPI(TestPlanAPIFactory):
 
     def get_completed_testplans(self, **kwargs):
         response = self.get_all_test_plans(**kwargs)
-        all_test_plans = response.json()['testPlans']
+        all_test_plans = response['testPlans']
         completed_test_plans = [test_plan for test_plan in all_test_plans if test_plan['status'] == 'Completed']
         return completed_test_plans
 

--- a/api_testing/apis/test_plan_api.py
+++ b/api_testing/apis/test_plan_api.py
@@ -167,14 +167,14 @@ class TestPlanAPI(TestPlanAPIFactory):
         return testplans_response.json()['testPlans']
 
     def get_completed_testplans(self, **kwargs):
-        response = self.get_all_test_plans(**kwargs)
+        response, payload = self.get_all_test_plans(**kwargs)
         all_test_plans = response['testPlans']
         completed_test_plans = [test_plan for test_plan in all_test_plans if test_plan['status'] == 'Completed']
         return completed_test_plans
 
     def get_inprogress_testplans(self, **kwargs):
-        response = self.get_all_test_plans(**kwargs)
-        all_test_plans = response.json()['testPlans']
+        response, payload = self.get_all_test_plans(**kwargs)
+        all_test_plans = response['testPlans']
         inprogress_test_plans = [test_plan for test_plan in all_test_plans if test_plan['status'] == 'InProgress']
         return inprogress_test_plans
 

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -489,8 +489,7 @@ class Order(Orders):
         self.sleep_small()
 
     def set_material_type_of_first_suborder(self, material_type='', sub_order_index=0):
-        suborder_table_rows = self.base_selenium.get_table_rows(
-            element='order:suborder_table')
+        suborder_table_rows = self.base_selenium.get_table_rows(element='order:suborder_table')
         suborder_row = suborder_table_rows[sub_order_index]
         suborder_elements_dict = self.base_selenium.get_row_cells_id_dict_related_to_header(
             row=suborder_row, table_element='order:suborder_table')

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -74,6 +74,7 @@ class Orders(BasePages):
         table_records = self.result_table(element='general:table')
         self.open_row_options(row=table_records[index])
         self.base_selenium.click(element='orders:mainorder_duplicate')
+        self.wait_until_page_is_loaded()
 
     def duplicate_sub_order_from_table_overview(self, index=0, number_of_copies=1):
         self.info('duplicate suborder from the order\'s active table')

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2109,7 +2109,8 @@ class OrdersTestCases(BaseTest):
         test_unit = self.order_page.set_test_unit()
         self.order_page.set_test_plan(test_plan=selected_test_plan['testPlanName'])
         self.info('duplicated order material is {}, article {}, test_unit {} and test_plan {}'.
-                  format(selected_test_plan['materialType'], article, test_unit, test_plan))
+                  format(selected_test_plan['materialType'], selected_test_plan['article'][0],
+                         test_unit, selected_test_plan['testPlanName']))
         self.order_page.save(save_btn='order:save_btn', sleep=True)
         self.info("navigate to orders' page to make sure that order duplicated correctly with selected data")
         self.order_page.get_orders_page()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2077,38 +2077,35 @@ class OrdersTestCases(BaseTest):
 
         LIMS-6219
         """
-        # get the random main order data
+        self.info('get random order ')
         orders, payload = self.orders_api.get_all_orders(limit=50)
         main_order = random.choice(orders['orders'])
         self.order_page.search(main_order['orderNo'])
-        # duplicate the main order
+        self.info('duplicate the main order')
         self.order_page.duplicate_main_order_from_order_option()
-        # make sure that its the duplication page
-        self.assertTrue('duplicateMainOrder' in self.base_selenium.get_url())
-        # make sure that the new order has different order No
-        self.order_page.sleep_small()
+
         duplicated_order_number = self.order_page.get_order_number()
-        self.order_page.info('order to be duplicated is {}, new order no is {}'.
-                             format(main_order['orderNo'], duplicated_order_number))
+        self.info('order to be duplicated is {}, new order no is {}'.
+                  format(main_order['orderNo'], duplicated_order_number))
         self.assertNotEqual(main_order['orderNo'], duplicated_order_number)
-        # change material type
-        self.order_page.open_suborder_edit()
-        self.order_page.sleep_medium()
-        material_type = self.order_page.set_material_type()
+
+        self.info('change material type of first suborder')
+        material_type = self.order_page.set_material_type_of_first_suborder()
+
         self.info('Make sure that article and test units are empty')
         self.assertEqual(self.base_selenium.get_value(element='order:article'), None)
         self.assertEqual(self.base_selenium.get_value(element='order:test_unit'), None)
+        self.assertEqual(self.base_selenium.get_value(element='order:test_plan'), None)
+
+        self.info('select random article, test unit and test plan')
         article = self.order_page.set_article()
         test_unit = self.order_page.set_test_unit()
         self.info('duplicated order material is {}, article {}, and test_unit {}'.
                   format(material_type, article, test_unit))
-        # save the duplicated order after edit
         self.order_page.save(save_btn='order:save_btn', sleep=True)
-        # go back to the table view
+        self.info("navigate to orders' page to make sure that order duplicated correctly with selected data")
         self.order_page.get_orders_page()
-        # search for the created order no
         self.order_page.search(duplicated_order_number)
-        # get the search result text
         child_data = self.order_page.get_child_table_data()
         if len(child_data) > 1:
             suborder_data = child_data[-1]
@@ -2116,5 +2113,5 @@ class OrdersTestCases(BaseTest):
             suborder_data = child_data[0]
         # check that it exists
         self.assertEqual(suborder_data['Material Type'], material_type)
-        self.assertEqual(suborder_data['Article Name'], article)
+        self.assertEqual(suborder_data['Article Name'].replce("'",""), article)
         self.assertEqual(suborder_data['Test Units'], test_unit)

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2109,7 +2109,7 @@ class OrdersTestCases(BaseTest):
         test_unit = self.order_page.set_test_unit()
         test_plan = self.order_page.set_test_plan(test_plan=selected_test_plan['testPlanName'])
         self.info('duplicated order material is {}, article {}, test_unit {} and test_plan {}'.
-                  format(material_type, article, test_unit, test_plan))
+                  format(selected_test_plan['materialType'], article, test_unit, test_plan))
         self.order_page.save(save_btn='order:save_btn', sleep=True)
         self.info("navigate to orders' page to make sure that order duplicated correctly with selected data")
         self.order_page.get_orders_page()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2084,6 +2084,7 @@ class OrdersTestCases(BaseTest):
         self.order_page.search(main_order['orderNo'])
         self.info('duplicate the main order')
         self.order_page.duplicate_main_order_from_order_option()
+        self.order_page.wait_until_page_is_loaded()
         duplicated_order_number = self.order_page.get_order_number()
         self.info('order to be duplicated is {}, new order no is {}'.
                   format(main_order['orderNo'], duplicated_order_number))
@@ -2091,7 +2092,7 @@ class OrdersTestCases(BaseTest):
         
         self.info('get material type of first suborder')
         old_material_type = self.order_page.get_material_type_of_first_suborder()
-        self.info('get completed test plan with differnt material type')
+        self.info('get completed test plan with different material type')
         self.test_plan_api = TestPlanAPI()
         completed_test_plans = self.test_plan_api.get_completed_testplans()
         for test_plan in completed_test_plans:

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2113,5 +2113,5 @@ class OrdersTestCases(BaseTest):
             suborder_data = child_data[0]
         # check that it exists
         self.assertEqual(suborder_data['Material Type'], material_type)
-        self.assertEqual(suborder_data['Article Name'].replce("'",""), article)
+        self.assertEqual(suborder_data['Article Name'].replace("'",""), article)
         self.assertEqual(suborder_data['Test Units'], test_unit)

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2072,13 +2072,13 @@ class OrdersTestCases(BaseTest):
         for record in analysis_records:
             self.assertEqual(record['Order No.'], formated_order_no)
 
-        def test033_Duplicate_main_order_and_cahange_materiel_type(self):
+    def test033_Duplicate_main_order_and_cahange_materiel_type(self):
         """
         duplicate the main order then change the materiel type
 
         LIMS-6219
         """
-        self.info('get random order ')
+        self.info('get random order')
         orders, payload = self.orders_api.get_all_orders(limit=50)
         main_order = random.choice(orders['orders'])
         self.order_page.search(main_order['orderNo'])
@@ -2088,17 +2088,17 @@ class OrdersTestCases(BaseTest):
         self.info('order to be duplicated is {}, new order no is {}'.
                   format(main_order['orderNo'], duplicated_order_number))
         self.assertNotEqual(main_order['orderNo'], duplicated_order_number)
-
-        self.info('change material type of first suborder')
-
+        
+        self.info('get material type of first suborder')
+        old_material_type = self.order_page.get_material_type_of_first_suborder()
+        self.info('get completed test plan with differnt material type')
         self.test_plan_api = TestPlanAPI()
         completed_test_plans = self.test_plan_api.get_completed_testplans()
-        old_material_type = self.order_page.get_material_type_of_first_suborder()
         for test_plan in completed_test_plans:
             if test_plan['materialType'] != old_material_type:
                 selected_test_plan = test_plan
                 break
-
+        self.info('change material type of first suborder')
         self.order_page.set_material_type_of_first_suborder(material_type=selected_test_plan['materialType'])
         self.info('Make sure that article, test unit, and test plan are empty')
         self.assertEqual(self.base_selenium.get_value(element='order:article'), None)

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2105,9 +2105,9 @@ class OrdersTestCases(BaseTest):
         self.assertEqual(self.base_selenium.get_value(element='order:test_unit'), None)
         self.assertEqual(self.base_selenium.get_value(element='order:test_plan'), None)
         self.info('select random article, test unit and test plan')
-        article = self.order_page.set_article(article=selected_test_plan['article'][0])
+        self.order_page.set_article(article=selected_test_plan['article'][0])
         test_unit = self.order_page.set_test_unit()
-        test_plan = self.order_page.set_test_plan(test_plan=selected_test_plan['testPlanName'])
+        self.order_page.set_test_plan(test_plan=selected_test_plan['testPlanName'])
         self.info('duplicated order material is {}, article {}, test_unit {} and test_plan {}'.
                   format(selected_test_plan['materialType'], article, test_unit, test_plan))
         self.order_page.save(save_btn='order:save_btn', sleep=True)
@@ -2122,6 +2122,6 @@ class OrdersTestCases(BaseTest):
         
         self.info('Make sure that suborder data is correct')
         self.assertEqual(suborder_data['Material Type'], selected_test_plan['materialType'])
-        self.assertEqual(suborder_data['Article Name'].replace("'", ""), article)
+        self.assertEqual(suborder_data['Article Name'].replace("'", ""), selected_test_plan['article'][0])
         self.assertEqual(suborder_data['Test Units'], test_unit)
-        self.assertEqual(suborder_data['Test Plans'], test_plan)
+        self.assertEqual(suborder_data['Test Plans'], selected_test_plan['testPlanName'])


### PR DESCRIPTION
```
➜  1lims-automation git:(LIMS-6219) nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test033_Duplicate_main_order_and_cahange_materiel_type
2020-04-12 06:55:38.321 | INFO     | api_testing.apis.base_api:info:70 - Get authorized api session.
2020-04-12 06:55:39.370 | INFO     | api_testing.apis.base_api:info:70 - session ID : eyJhbGciOi .....
duplicate the main order then change the materiel type ...      
2020-04-12 06:55:39.788 | INFO     | ui_testing.testcases.base_test:info:122 - Test case : test033_Duplicate_main_order_and_cahange_materiel_type
2020-04-12 06:57:27.811 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-04-12 06:57:28.554 | INFO     | ui_testing.testcases.base_test:info:122 - get random order
2020-04-12 06:57:28.555 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/orders
2020-04-12 06:57:29.444 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-12 06:57:40.931 | INFO     | ui_testing.testcases.base_test:info:122 - duplicate the main order
2020-04-12 06:57:40.931 | INFO     | ui_testing.pages.base_pages:info:274 -  duplicate suborder from the order's active table
2020-04-12 06:57:40.967 | INFO     | ui_testing.pages.base_pages:info:274 -  open record options menu
2020-04-12 06:57:41.129 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-12 06:57:43.588 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-04-12 06:57:45.374 | INFO     | ui_testing.testcases.base_test:info:122 - order to be duplicated is 84764-20, new order no is 
2020-04-12 06:57:45.375 | INFO     | ui_testing.testcases.base_test:info:122 - get material type of first suborder
2020-04-12 06:57:46.856 | INFO     | ui_testing.testcases.base_test:info:122 - get completed test plan with differnt material type
2020-04-12 06:57:46.856 | INFO     | api_testing.apis.base_api:info:70 - GET : https://automation.1lims.com/api/testPlans
2020-04-12 06:57:47.701 | INFO     | api_testing.apis.base_api:info:70 - Status code: 1
2020-04-12 06:57:47.702 | INFO     | ui_testing.testcases.base_test:info:122 - change material type of first suborder
2020-04-12 06:57:56.188 | INFO     | ui_testing.testcases.base_test:info:122 - Make sure that article, test unit, and test plan are empty
2020-04-12 06:57:56.366 | INFO     | ui_testing.testcases.base_test:info:122 - select random article, test unit and test plan
2020-04-12 06:58:18.947 | INFO     | ui_testing.testcases.base_test:info:122 - duplicated order material is newwwwwwww, article 366d9cc08c, test_unit tumibi3concen and test_plan asdfdf
2020-04-12 06:58:18.956 | INFO     | ui_testing.pages.base_pages:info:274 -  save the changes
2020-04-12 06:58:19.003 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-12 06:58:21.212 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-04-12 06:58:23.214 | INFO     | ui_testing.testcases.base_test:info:122 - navigate to orders' page to make sure that order duplicated correctly with selected data
2020-04-12 06:58:26.226 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-04-12 06:58:38.469 | INFO     | ui_testing.pages.base_pages:sleep_medium:47 -  Medium sleep.
2020-04-12 06:58:51.238 | INFO     | ui_testing.testcases.base_test:info:122 - Make sure that suborder data is correct
2020-04-12 06:58:51.309 | INFO     | ui_testing.testcases.base_test:info:122 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 191.523s

OK

```