### PR TITLE
LIMS-4264: edit suborder material type 

### DIFF
--- a/ui_testing/pages/analyses_page.py
+++ b/ui_testing/pages/analyses_page.py
@@ -10,3 +10,8 @@ class AllAnalysesPage(BasePages):
         self.base_selenium.get(url=self.analyses)
         self.wait_until_page_is_loaded()
 
+    def filter_by_analysis_number(self, filter_text):
+        self.info('Filter by analysis number : {}'.format(filter_text))
+        self.open_filter_menu()
+        self.filter_by(filter_element='analysis_page:analysis_no_filter', filter_text=filter_text, field_type='text')
+        self.filter_apply()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -1046,8 +1046,6 @@ class OrdersTestCases(BaseTest):
 
         self.assertEqual(len(rows_count) - 1, 1)
 
-    # will continue with us
-    @skip('https://modeso.atlassian.net/browse/LIMS-4914')
     def test027_update_material_type(self):
         """
         Apply this on suborder number 5 for example:-
@@ -1055,77 +1053,59 @@ class OrdersTestCases(BaseTest):
         (All analysis created with this order and test plan will be deleted )
         -Once you press on OK button, the material type & article & test pan will delete
         -You can update it by choose another one and choose corresponding article & test plan
+
         LIMS-4264
         """
+        self.info('get random order')
+        orders, _ = self.orders_api.get_all_orders(limit=50)
+        order = random.choice(orders['orders'])
+        suborders, _ = self.orders_api.get_suborder_by_order_id(order['id'])
+        suborder = suborders['orders'][0]
+        suborder_update_index = len(suborders['orders']) - 1
 
-        # new random order data
-        basic_order_data = self.get_random_order_data()
-        new_material_type = basic_order_data['material_type']
-        new_article = basic_order_data['article_name']
-        new_testplan_name = basic_order_data['testplan']
-        testplan_testunits = basic_order_data['testunits_in_testplan']
+        self.info('get random completed test plan with different material type')
+        test_plans = TestPlanAPI().get_completed_testplans()
+        # I need to make sure that material type not equal '47d56b4399' due to this open bug
+        # https://modeso.atlassian.net/browse/LIMS-7710
+        test_plans_without_duplicate = [test_plan for test_plan in test_plans if
+                                        test_plan['materialType'] not in
+                                        [suborder['materialType'], '47d56b4399']]
+        test_plan = random.choice(test_plans_without_duplicate)
 
-        self.base_selenium.LOGGER.info('Create new order with intial data')
-        # initial data is static because it won't affect the test case, but the updating data is generated dynamically
-        self.order_page.create_new_order(multiple_suborders=3, test_plans=['tp1'], material_type='Raw Material',
-                                         test_units=[''])
+        self.info('update material type of order {} with {}'.format(order['orderNo'], test_plan['materialType']))
+        self.orders_page.get_order_edit_page_by_id(order['id'])
+        self.order_page.update_suborder(sub_order_index=suborder_update_index, material_type=test_plan['materialType'])
+        confirm_edit = self.base_selenium.check_element_is_exist(element="general:confirmation_pop_up")
+        confirm_edit_message = self.base_selenium.get_text(element="general:confirmation_pop_up")
+        self.assertTrue(confirm_edit)
+        self.assertIn('All analysis created with this order and test plan will be deleted', confirm_edit_message)
+        self.info('confirm pop_up')
+        self.orders_page.confirm_popup()
+        self.info('assert test plan and articles are empty')
+        self.assertFalse(self.order_page.get_test_plan())
+        self.assertEqual(self.order_page.get_article(), 'Search')  # empty article return 'Search'
+        self.info("set article to {} and test plan to {}".format(test_plan['article'][0], test_plan['testPlanName']))
+        if test_plan['article'][0] == 'all':
+            article = self.order_page.set_article('')
+        else:
+            self.order_page.set_article(test_plan['article'][0])
+            article = test_plan['article'][0]
 
-        self.base_selenium.LOGGER.info('Creating new order with 2 suborders')
-        order_no = self.order_page.create_new_order(multiple_suborders=1, test_plans=['tp1'],
-                                                    material_type='Raw Material')
-        self.base_selenium.LOGGER.info('Created new order with no #{}, and test plan {}'.format(order_no, 'tp1'))
-
-        # getting data of the created orders to make sure that everything created correctly
-        rows = self.order_page.result_table()
-        selected_order_data = self.base_selenium.get_row_cells_dict_related_to_header(row=rows[0])
-        analysis_no = selected_order_data['Analysis No.']
-
-        self.order_page.get_random_x(row=rows[1])
-        self.order_page.update_suborder(sub_order_index=1, test_plans=['tp2'])
-        self.base_selenium.LOGGER.info('Update order with test plans: {}'.format('tp2'))
-        sub_order_data = self.order_page.get_suborder_data(sub_order_index=1, test_plan=True)
-        suborder_testplans = sub_order_data['test_plan']
-        suborder_testplans = suborder_testplans.split('|')
-        self.base_selenium.LOGGER.info('order update and has test plans: {}'.format(suborder_testplans))
-
-        # getting the length of the table, should be 2
-        self.base_selenium.LOGGER.info(
-            'Get analysis page to filter with order no to make sure that new test plan did not trigger new analysis')
-        self.analyses_page.get_analyses_page()
-
-        self.base_selenium.LOGGER.info('Filter analysis page with order no: #{}'.format(order_no))
-        analysis_records = self.analyses_page.search(value=order_no)
-        analysis_count = len(analysis_records) - 1
-        self.base_selenium.LOGGER.info(
-            'comparing count of analysis triggered with this order after adding new test plan')
-        self.base_selenium.LOGGER.info('analysis triggered count: {}, and it should be 2'.format(analysis_count))
-        self.assertEqual(2, analysis_count)
-
-        # get analysis data to make sure that the newly added test plan is added to analysis
-        self.base_selenium.LOGGER.info(
-            'Check the test plans in analysis from active table compared with selected test plans in order')
-        selected_analysis_data = self.base_selenium.get_row_cells_dict_related_to_header(row=analysis_records[0])
-        analysis_test_plans = selected_analysis_data['Test Plans'].split(',')
-
-        self.base_selenium.LOGGER.info('+ Comapring test plans in analysis and order')
-        self.base_selenium.LOGGER.info(
-            '+ Assert order\'s testplans are: {}, analysis test plans are: {}'.format(suborder_testplans,
-                                                                                      analysis_test_plans))
-        self.assertEqual(set(analysis_test_plans) == set(suborder_testplans), True)
-
-        self.base_selenium.LOGGER.info('C omparing analysis status')
-        # making sure that the status remained open after adding new test plan
-        analysis_status = selected_analysis_data['Status']
-        analysis_no_from_analysis_table = selected_analysis_data['Analysis No.']
-        self.base_selenium.LOGGER.info(
-            'Analysis with no #{}, has status: {}'.format(analysis_no_from_analysis_table, analysis_status))
-        self.base_selenium.LOGGER.info(
-            '+ Assert analysis has status: {}, and it should be: {}'.format(analysis_status, 'Open'))
-        self.assertEqual(analysis_status, 'Open')
-
-        # get order data to be updated
-        self.base_selenium.LOGGER.info('Get order data to remove a test plan from the order')
+        self.order_page.set_test_plan(test_plan['testPlanName'])
+        self.info('save the changes then refresh')
+        self.order_page.save(save_btn='order:save_btn')
+        self.base_selenium.refresh()
+        self.info('get order data after edit and refresh')
+        order_data_after_refresh = self.order_page.get_suborder_data()
+        suborder_after_refresh = order_data_after_refresh['suborders'][suborder_update_index]
+        self.info('navigate to analysis page to make sure analysis corresponding to suborder updated')
         self.order_page.get_orders_page()
+        self.order_page.navigate_to_analysis_tab()
+        self.analyses_page.filter_by_analysis_number(suborder_after_refresh['analysis_no'])
+        analyses = self.analyses_page.result_table()[0]
+        self.assertIn(test_plan['materialType'], analyses.text)
+        self.assertIn(article, analyses.text)
+        self.assertIn(test_plan['testPlanName'], analyses.text)
 
     # will continue with us & then put the test case number for it
     def test026_update_suborder_article(self):


### PR DESCRIPTION
-When user update the materiel type from table view once I delete it message will appear (All analysis created with this order and test plan will be deleted )  
-Once you press on OK button, the material type & article & test pan will delete 
-You can update it by choose another one and choose corresponding article & test plan 
Test case link : https://modeso.atlassian.net/browse/LIMS-4264

I needed to check that material type that I use not equla that in this bug : https://modeso.atlassian.net/browse/LIMS-7710
So, after this bug resolved I need to update this check 
https://github.com/modeso-open-source/1lims-automation/blob/LIMS-4264-gh/ui_testing/testcases/basic_tests/test06_orders.py#L1072

```
➜  1lims-automation git:(LIMS-4264-gh) nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test027_update_material_type
2020-05-03 15:35:30.234 | INFO     | api_testing.apis.base_api:info:76 - Get authorized api session.
2020-05-03 15:35:30.917 | INFO     | api_testing.apis.base_api:info:76 - session ID : eyJhbGciOi .....
Apply this on suborder number 5 for example:- ...       
2020-05-03 15:35:31.091 | INFO     | ui_testing.testcases.base_test:info:129 - Test case : test027_update_material_type
2020-05-03 15:36:01.311 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-03 15:36:02.122 | INFO     | ui_testing.testcases.base_test:info:129 - get random order
2020-05-03 15:36:02.122 | INFO     | api_testing.apis.base_api:info:76 - GET : https://automation.1lims.com/api/orders
2020-05-03 15:36:03.054 | INFO     | api_testing.apis.base_api:info:76 - Status code: 1
2020-05-03 15:36:03.054 | INFO     | api_testing.apis.base_api:info:76 - GET : https://automation.1lims.com/api/orders/get/subOrder/byMainOrderId?orderId=1110&deleted=0
2020-05-03 15:36:03.466 | INFO     | api_testing.apis.base_api:info:76 - Status code: 1
2020-05-03 15:36:03.467 | INFO     | ui_testing.testcases.base_test:info:129 - get random completed test plan with different material type
2020-05-03 15:36:03.467 | INFO     | api_testing.apis.base_api:info:76 - GET : https://automation.1lims.com/api/testPlans
2020-05-03 15:36:04.222 | INFO     | api_testing.apis.base_api:info:76 - Status code: 1
2020-05-03 15:36:04.222 | INFO     | ui_testing.testcases.base_test:info:129 - update material type of order 8478598-2020 with 0bc056e545
2020-05-03 15:36:06.974 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-05-03 15:36:18.016 | INFO     | ui_testing.pages.order_page:update_suborder:396 -  Set material type : 0bc056e545
2020-05-03 15:36:30.771 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-05-03 15:36:35.776 | INFO     | ui_testing.pages.order_page:update_suborder:406 -  Set test plan : [] for 0 time(s)
2020-05-03 15:36:35.777 | INFO     | ui_testing.pages.order_page:update_suborder:410 -  Set test unit : [] for 0 time(s)
2020-05-03 15:36:35.901 | INFO     | ui_testing.testcases.base_test:info:129 - confirm pop_up
2020-05-03 15:36:35.901 | INFO     | ui_testing.pages.base_pages:confirm_popup:73 - confirming the popup
2020-05-03 15:36:41.115 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-05-03 15:36:46.116 | INFO     | ui_testing.testcases.base_test:info:129 - assert test plan and articles are empty
2020-05-03 15:36:46.402 | INFO     | ui_testing.testcases.base_test:info:129 - set article to a381b76cba and test plan to 482add8e0c
2020-05-03 15:37:03.735 | INFO     | ui_testing.testcases.base_test:info:129 - save the changes then refresh
2020-05-03 15:37:03.735 | INFO     | ui_testing.pages.base_pages:info:274 -  save the changes
2020-05-03 15:37:03.770 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-05-03 15:37:06.037 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-05-03 15:37:14.964 | INFO     | ui_testing.testcases.base_test:info:129 - get order data after edit and refresh
2020-05-03 15:37:15.078 | INFO     | ui_testing.pages.order_page:get_suborder_data:328 - getting main order data
2020-05-03 15:37:15.268 | INFO     | ui_testing.pages.order_page:get_suborder_data:335 - getting suborders data
2020-05-03 15:37:15.916 | INFO     | ui_testing.testcases.base_test:info:129 - navigate to analysis page to make sure analysis corresponding to suborder updated
2020-05-03 15:37:18.482 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-03 15:37:25.308 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-03 15:37:25.338 | INFO     | ui_testing.pages.base_pages:info:274 -  filter by analysis number : 1'725-20
2020-05-03 15:37:25.339 | INFO     | ui_testing.pages.base_pages:open_filter_menu:82 -  Open Filter
2020-05-03 15:37:42.346 | INFO     | ui_testing.testcases.base_test:info:129 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 131.256s

OK
```