### PR TITLE
LIMS-6854: Can't delete multiple orders records at the same time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,4 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests-3.4 -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test024_archive_sub_order
-  - xvfb-run -a nosetests-3.4 -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test005_restore_archived_orders
-
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test036_delete_multiple_orders

--- a/ui_testing/pages/base_pages.py
+++ b/ui_testing/pages/base_pages.py
@@ -176,11 +176,12 @@ class BasePages:
         self.base_selenium.click(element='general:restore')
         self.confirm_popup()
 
-    def delete_selected_item(self):
+    def delete_selected_item(self, confirm_pop_up=True):
         self.base_selenium.scroll()
         self.base_selenium.click(element='general:right_menu')
         self.base_selenium.click(element='general:delete')
-        self.confirm_popup()
+        if confirm_pop_up:
+            self.confirm_popup()
 
     def archive_selected_items(self):
         self.base_selenium.scroll()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2189,16 +2189,17 @@ class OrdersTestCases(BaseTest):
         self.assertIn(duplicated_suborder_data['Test Units'], test_units)
         self.assertIn(duplicated_suborder_data['Test Plans'], test_plans)
 
-    @skip('https://modeso.atlassian.net/browse/LIMSA-136')
     def test036_delete_multiple_orders(self):
         """
-        Orders: Make sure that you can delete multiple orders records at the same time
+        Orders: Make sure that you can't delete multiple orders records at the same time
 
         LIMS-6854
         """
         self.info("navigate to archived items' table")
         self.orders_page.get_archived_items()
-        selected_orders_data, selected_rows = self.orders_page.select_random_multiple_table_rows()
-        self.orders_page.delete_selected_item()
-        for order in selected_orders_data:
-            self.assertFalse(self.orders_page.search(order['Order No.']))
+        self.orders_page.select_random_multiple_table_rows()
+        self.orders_page.delete_selected_item(confirm_pop_up=False)
+        confirm_edit = self.base_selenium.check_element_is_exist(element="general:cant_delete_message")
+        confirm_edit_message = self.base_selenium.get_text(element="general:confirmation_pop_up")
+        self.assertTrue(confirm_edit)
+        self.assertIn('You cannot do this action on more than one record', confirm_edit_message)

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2171,3 +2171,16 @@ class OrdersTestCases(BaseTest):
         self.assertIn(duplicated_suborder_data['Test Units'], test_units)
         self.assertIn(duplicated_suborder_data['Test Plans'], test_plans)
 
+    @skip('https://modeso.atlassian.net/browse/LIMSA-136')
+    def test036_delete_multiple_orders(self):
+        """
+        Orders: Make sure that you can delete multiple orders records at the same time
+
+        LIMS-6854
+        """
+        self.info("navigate to archived items' table")
+        self.orders_page.get_archived_items()
+        selected_orders_data, selected_rows = self.orders_page.select_random_multiple_table_rows()
+        self.orders_page.delete_selected_item()
+        for order in selected_orders_data:
+            self.assertFalse(self.orders_page.search(order['Order No.']))


### PR DESCRIPTION
make sure that you can't delete multiple orders at same time.

```
➜  1lims-automation git:(LIMS-6854) nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test036_delete_multiple_orders
2020-05-10 23:58:26.922 | INFO     | api_testing.apis.base_api:info:76 - Get authorized api session.
2020-05-10 23:58:27.629 | INFO     | api_testing.apis.base_api:info:76 - session ID : eyJhbGciOi .....
Orders: Make sure that you can't delete multiple orders records at the same time ...    
2020-05-10 23:58:27.793 | INFO     | ui_testing.testcases.base_test:info:129 - Test case : test036_delete_multiple_orders
2020-05-10 23:59:16.142 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:532 - wait until page is loaded
2020-05-10 23:59:17.562 | INFO     | ui_testing.testcases.base_test:info:129 - navigate to archived items' table
2020-05-10 23:59:18.266 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-05-10 23:59:23.327 | INFO     | ui_testing.pages.base_pages:info:275 -  no. of selected rows 5 
2020-05-10 23:59:33.988 | INFO     | ui_testing.testcases.base_test:info:129 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 66.196s

OK
```
