### PR TITLE
LIMS-6222: Duplicate main order then change the contact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test004_archive_main_order --tc-file=config.ini
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test037_duplicate_main_order_change_contact

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -52,13 +52,15 @@ class Order(Orders):
         self.set_article(article=article)
         return self.base_selenium.check_item_in_items(element='order:article', item_text=article)
 
-    def set_contact(self, contact=''):
+    def set_contact(self, contact='', remove_old=False):
+        if remove_old:
+            self.base_selenium.clear_items_in_drop_down(element='order:contact')
         if contact:
             self.base_selenium.select_item_from_drop_down(
                 element='order:contact', item_text=contact)
         else:
             self.base_selenium.select_item_from_drop_down(
-                element='order:contact')
+                element='order:contact', avoid_duplicate=True)
             return self.get_contact()
 
     def get_contact(self, order_row=None):

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2196,6 +2196,7 @@ class OrdersTestCases(BaseTest):
         """
         self.info('get random main order data')
         orders, payload = self.orders_api.get_all_orders(limit=50)
+        self.assertEqual(orders['status'], 1)
         main_order = random.choice(orders['orders'])
         self.info("duplicate order No {}".format(main_order['orderNo']))
         self.order_page.search(main_order['orderNo'])
@@ -2206,7 +2207,7 @@ class OrdersTestCases(BaseTest):
         self.orders_page.get_orders_page()
         self.orders_page.filter_by_order_no(duplicted_order_no)
         order = self.orders_page.get_the_latest_row_data()
-        self.assertEqual(new_contact[0]['name'], order['Contact Name'])
+        self.assertEqual(new_contact[0], order['Contact Name'])
 
     def test036_delete_multiple_orders(self):
         """

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2189,3 +2189,22 @@ class OrdersTestCases(BaseTest):
         self.assertIn(duplicated_suborder_data['Test Units'], test_units)
         self.assertIn(duplicated_suborder_data['Test Plans'], test_plans)
 
+    def test037_duplicate_main_order_change_contact(self):
+        """
+        Duplicate from the main order Approach: Duplicate then change the contact
+
+        LIMS-6222
+        """
+        self.info('get random main order data')
+        orders, payload = self.orders_api.get_all_orders(limit=50)
+        main_order = random.choice(orders['orders'])
+        self.info("duplicate order No {}".format(main_order['orderNo']))
+        self.order_page.search(main_order['orderNo'])
+        self.order_page.duplicate_main_order_from_order_option()
+        new_contact = self.order_page.set_contact(contact='', remove_old=True)
+        duplicted_order_no = self.order_page.get_no()
+        self.order_page.save(save_btn='order:save')
+        self.orders_page.get_orders_page()
+        self.orders_page.filter_by_order_no(duplicted_order_no)
+        order = self.orders_page.get_the_latest_row_data()
+        self.assertEqual(new_contact[0]['name'], order['Contact Name'])


### PR DESCRIPTION
-Duplicate main order then change the contact
- make sure new record created with the new contact 
```
➜  1lims-automation git:(LIMS-6222) nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test037_duplicate_main_order_change_contact
2020-05-10 00:19:51.442 | INFO     | api_testing.apis.base_api:info:76 - Get authorized api session.
2020-05-10 00:19:52.250 | INFO     | api_testing.apis.base_api:info:76 - session ID : eyJhbGciOi .....
Duplicate from the main order Approach: Duplicate then change the contact ...   
2020-05-10 00:19:52.413 | INFO     | ui_testing.testcases.base_test:info:129 - Test case : test037_duplicate_main_order_change_contact
2020-05-10 00:20:50.211 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-10 00:20:50.727 | INFO     | ui_testing.testcases.base_test:info:129 - get random main order data
2020-05-10 00:20:50.727 | INFO     | api_testing.apis.base_api:info:76 - GET : https://automation.1lims.com/api/orders
2020-05-10 00:20:51.449 | INFO     | api_testing.apis.base_api:info:76 - Status code: 1
2020-05-10 00:20:51.450 | INFO     | ui_testing.testcases.base_test:info:129 - duplicate order No 8478656
2020-05-10 00:21:07.357 | INFO     | ui_testing.pages.base_pages:info:274 -  duplicate suborder from the order's active table
2020-05-10 00:21:07.393 | INFO     | ui_testing.pages.base_pages:info:274 -  open record options menu
2020-05-10 00:21:12.553 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-05-10 00:21:20.104 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-10 00:21:37.118 | INFO     | ui_testing.pages.base_pages:info:274 -  save the changes
2020-05-10 00:21:37.163 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-05-10 00:21:39.428 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-05-10 00:21:44.227 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:531 - wait until page is loaded
2020-05-10 00:21:45.878 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:130 -  + Filter by order no. : 8'478'705
2020-05-10 00:21:53.960 | INFO     | ui_testing.testcases.base_test:info:129 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 121.548s

OK
```