### PR TITLE
update create order using api to match payload with UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,5 @@ script:
   #- export TESTS='test04_testunits.py:TestUnitsTestCases.test011_create_test_unit_with_random_category'
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then export TESTS=''; fi
   - cd $TRAVIS_BUILD_DIR && export PYTHONPATH='./'
-  - xvfb-run -a nosetests-3.4 -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test017_validate_order_test_unit_test_plan_edit_mode --tc-file=config.ini
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test040_test_create_order
+  - xvfb-run -a nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test041_test_create_order_with_multiple_testplans

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -50,19 +50,13 @@ class OrdersAPIFactory(BaseAPI):
         :param kwargs:
         :return: response, payload
         """
-
         order_no = self.get_auto_generated_order_no()[0]['id']
-
-        testplan = random.choice(TestPlanAPI().get_completed_testplans())
+        testplan = random.choice(TestPlanAPI().get_completed_testplans(limit=1000))
         material_type = testplan['materialType']
         material_type_id = GeneralUtilitiesAPI().get_material_id(material_type)
-        article = testplan['article'][0]
-        article_api = ArticleAPI()
-        if article == "all":
-            res, _ = article_api.get_all_articles(limit=20)
-        else:
-            res, _ = article_api.quick_search_article(name=article)
-        article_id = res['articles'][0]['id']
+        testplan_form_data = TestPlanAPI()._get_testplan_form_data(id=testplan['id'])[0]
+        article = testplan_form_data['testPlan']['selectedArticles'][0]['name']
+        article_id =testplan_form_data['testPlan']['selectedArticles'][0]['id']
         testunit = random.choice(TestUnitAPI().list_testunit_by_name_and_material_type(
             materialtype_id=material_type_id)[0]['testUnits'])
 
@@ -240,17 +234,11 @@ class OrdersAPI(OrdersAPIFactory):
 
     def create_order_with_double_test_plans(self):
         testplan = random.choice(TestPlanAPI().get_completed_testplans())
+        testplan_form_data = TestPlanAPI()._get_testplan_form_data(id=testplan['id'])[0]
+        article = testplan_form_data['testPlan']['selectedArticles'][0]['name']
+        article_id = testplan_form_data['testPlan']['selectedArticles'][0]['id']
         material_type = testplan['materialType']
         material_type_id = GeneralUtilitiesAPI().get_material_id(material_type)
-        article = testplan['article'][0]
-        article_api = ArticleAPI()
-        if article == "all":
-            res, _ = article_api.get_all_articles(limit=20)
-        else:
-            res, _ = article_api.quick_search_article(name=article)
-
-        article_id = res['articles'][0]['id']
-
         testunit = random.choice(TestUnitAPI().list_testunit_by_name_and_material_type(
             materialtype_id=material_type_id)[0]['testUnits'])
         testunit_data = TestUnitAPI().get_testunit_form_data(id=testunit['id'])[0]['testUnit']

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -57,6 +57,18 @@ class OrdersAPIFactory(BaseAPI):
         testplan_form_data = TestPlanAPI()._get_testplan_form_data(id=testplan['id'])[0]
         article = testplan_form_data['testPlan']['selectedArticles'][0]['name']
         article_id =testplan_form_data['testPlan']['selectedArticles'][0]['id']
+
+        #modify_test_plan_ID
+        testplan['id'] = testplan_form_data['testPlan']['testPlanEntity']['id']
+
+        # import ipdb; ipdb.set_trace()
+        # res, payload = ArticleAPI().list_testplans_by_article_and_materialtype(materialtype_id=material_type_id,
+        #                                                                       article_id=article_id)
+        # for _testplan in res['testPlans']:
+        #     if _testplan['number'] == testplan["number"]:
+        #         testplan["id"] = _testplan["id"]
+        #         break
+
         testunit = random.choice(TestUnitAPI().list_testunit_by_name_and_material_type(
             materialtype_id=material_type_id)[0]['testUnits'])
 

--- a/api_testing/apis/orders_api.py
+++ b/api_testing/apis/orders_api.py
@@ -57,17 +57,9 @@ class OrdersAPIFactory(BaseAPI):
         testplan_form_data = TestPlanAPI()._get_testplan_form_data(id=testplan['id'])[0]
         article = testplan_form_data['testPlan']['selectedArticles'][0]['name']
         article_id =testplan_form_data['testPlan']['selectedArticles'][0]['id']
+
         #modify_test_plan_ID
         testplan['id'] = testplan_form_data['testPlan']['testPlanEntity']['id']
-
-        # import ipdb; ipdb.set_trace()
-        # res, payload = ArticleAPI().list_testplans_by_article_and_materialtype(materialtype_id=material_type_id,
-        #                                                                       article_id=article_id)
-        # for _testplan in res['testPlans']:
-        #     if _testplan['number'] == testplan["number"]:
-        #         testplan["id"] = _testplan["id"]
-        #         break
-
         testunit = testplan_form_data['testPlan']['specifications'][0]
 
         test_date = self.get_current_date()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2174,3 +2174,11 @@ class OrdersTestCases(BaseTest):
         self.assertIn(duplicated_suborder_data['Test Units'], test_units)
         self.assertIn(duplicated_suborder_data['Test Plans'], test_plans)
 
+    def test040_test_creat_order(self):
+        import ipdb;ipdb.set_trace()
+        api, payload = self.orders_api.create_new_order()
+        self.info(payload)
+        self.orders_page.filter_by_order_no(payload[0]['orderNo'])
+        self.info(self.orders_page.get_the_latest_row_data())
+        self.info(self.orders_page.get_child_table_data())
+

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2190,8 +2190,6 @@ class OrdersTestCases(BaseTest):
         api, payload = self.orders_api.create_order_with_double_test_plans()
         self.info(payload)
         self.orders_page.search(payload[0]['orderNo'])
-        order_data = self.orders_page.get_the_latest_row_data()
-        self.assertEqual(order_data['Order No.'].split('-')[0].replace("'", ""), str(payload[0]['orderNo']))
         suborder_data = self.orders_page.get_child_table_data()[0]
         self.assertEqual(suborder_data['Test Plans'].split(',\n')[0], payload[0]['testPlans'][0]['testPlanName'])
         self.assertEqual(suborder_data['Test Plans'].split(',\n')[1], payload[0]['testPlans'][1]['testPlanName'])

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2188,7 +2188,6 @@ class OrdersTestCases(BaseTest):
 
     def test041_test_create_order_with_multiple_testplans(self):
         api, payload = self.orders_api.create_order_with_double_test_plans()
-        self.info(payload)
         self.orders_page.search(payload[0]['orderNo'])
         suborder_data = self.orders_page.get_child_table_data()[0]
         self.assertEqual(suborder_data['Test Plans'].split(',\n')[0], payload[0]['testPlans'][0]['testPlanName'])

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2174,11 +2174,29 @@ class OrdersTestCases(BaseTest):
         self.assertIn(duplicated_suborder_data['Test Units'], test_units)
         self.assertIn(duplicated_suborder_data['Test Plans'], test_plans)
 
-    def test040_test_creat_order(self):
-        import ipdb;ipdb.set_trace()
+    def test040_test_create_order(self):
         api, payload = self.orders_api.create_new_order()
         self.info(payload)
-        self.orders_page.filter_by_order_no(payload[0]['orderNo'])
-        self.info(self.orders_page.get_the_latest_row_data())
-        self.info(self.orders_page.get_child_table_data())
+        self.orders_page.search(payload[0]['orderNo'])
+        order_data = self.orders_page.get_the_latest_row_data()
+        self.assertEqual(order_data['Order No.'].split('-')[0].replace("'", ""), str(payload[0]['orderNo']))
+        suborder_data = self.orders_page.get_child_table_data()[0]
+        self.assertEqual(suborder_data['Test Plans'],  payload[0]['testPlans'][0]['name'])
+        self.assertEqual(suborder_data['Material Type'].replace(' ',''), payload[0]['materialType']['text'].replace(' ',''))
+        self.assertEqual(suborder_data['Article Name'], payload[0]['article']['text'])
+        self.assertEqual(suborder_data['Test Units'], payload[0]['selectedTestUnits'][0]['name'])
+
+    def test041_test_create_order_with_multiple_testplans(self):
+        api, payload = self.orders_api.create_order_with_double_test_plans()
+        self.info(payload)
+        self.orders_page.search(payload[0]['orderNo'])
+        order_data = self.orders_page.get_the_latest_row_data()
+        self.assertEqual(order_data['Order No.'].split('-')[0].replace("'", ""), str(payload[0]['orderNo']))
+        suborder_data = self.orders_page.get_child_table_data()[0]
+        self.assertEqual(suborder_data['Test Plans'].split(',\n')[0], payload[0]['testPlans'][0]['testPlanName'])
+        self.assertEqual(suborder_data['Test Plans'].split(',\n')[1], payload[0]['testPlans'][1]['testPlanName'])
+        self.assertEqual(suborder_data['Material Type'], payload[0]['materialType']['text'])
+        self.assertEqual(suborder_data['Article Name'], payload[0]['article']['text'])
+        self.assertEqual(suborder_data['Test Units'].split(',\n')[0], payload[0]['testUnits'][0]['name'])
+        self.assertEqual(suborder_data['Test Units'].split(',\n')[1], payload[0]['testUnits'][1]['name'])
 


### PR DESCRIPTION
I updated article ID with easier way, But about sending article ID in testplan payload in line : 
https://github.com/modeso-open-source/1lims-automation/blob/9314f89291e3551e3d410475f8eff3855665b281/api_testing/apis/orders_api.py#L180
as mazen told you, but I got that error 
```
{'status': 0, 'message': 'ER_NO_REFERENCED_ROW_2: Cannot add or update a child row: a foreign key constraint fails (`automation`.`orders_testplans`, CONSTRAINT `orders_testplans_ibfk_2` FOREIGN KEY (`testPlanId`) REFERENCES `lr_testplans` (`id`))'}

```
so I'm confused that may be I got mazen explanation wrong ?