### PR TITLE
create_order in order_page.py

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_cases: ["ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test039_duplicate_main_order_with_testPlan_and_testUnit_edit_both_0_change ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test039_duplicate_main_order_with_testPlan_and_testUnit_edit_both_1_add ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test040_duplicate_sub_order_with_testPlan_and_testUnit_change_both"]
+        test_cases: [""]
 
     steps:
       - uses: actions/checkout@master

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -116,7 +116,7 @@ class Order(Orders):
 
     def create_new_order(self, material_type='', article='', contact='', test_plans=[''], test_units=[''],
                          multiple_suborders=0, departments=''):
-        self.base_selenium.LOGGER.info(' Create new order.')
+        self.info(' Create new order.')
         self.click_create_order_button()
         self.set_new_order()
         self.set_contact(contact=contact)
@@ -140,7 +140,7 @@ class Order(Orders):
 
         self.save(save_btn='order:save_btn')
         self.base_selenium.LOGGER.info(' Order created with no : {} '.format(order_no))
-        return self.get_suborder_data()
+        return order_no
 
     def create_existing_order(self, no='', material_type='', article='', contact='', test_units=[],
                               multiple_suborders=0):
@@ -575,6 +575,4 @@ class Order(Orders):
         suborders = self.base_selenium.get_table_rows(element='order:suborder_table')
         suborder_row = suborders[index]
         suborder_data = self.get_suborder_data()
-        return  suborder_data
-
-
+        return suborder_data

--- a/ui_testing/testcases/basic_tests/test03_testplans.py
+++ b/ui_testing/testcases/basic_tests/test03_testplans.py
@@ -505,8 +505,9 @@ class TestPlansTestCases(BaseTest):
         self.order_page.get_orders_page()
 
         # create a new order with material type and article same as the saved ones
-        order_data = self.order_page.create_new_order(material_type=testplan_materialtype, article=testplan_article,
-                                                      test_plans=[testplan_name])
+        self.order_page.create_new_order(material_type=testplan_materialtype, article=testplan_article,
+                                         test_plans=[testplan_name])
+        order_data = self.order_page.get_suborder_data()
 
         # get the first suborder's testplan and make sure it's an empty string
         suborder_first_testplan = (((order_data['suborders'])[0])['testplans'])[0]

--- a/ui_testing/testcases/basic_tests/test05_contacts.py
+++ b/ui_testing/testcases/basic_tests/test05_contacts.py
@@ -369,8 +369,8 @@ class ContactsTestCases(BaseTest):
 
         self.base_selenium.LOGGER.info('create order with the desired contact to keep track of the updated')
         self.order_page.get_orders_page()
-        order_data = self.order_page.create_new_order(material_type='Raw Material', departments=departments,
-                                                      contact=contact_name, test_plans=[])
+        self.order_page.create_new_order(material_type='Raw Material', departments=departments,
+                                         contact=contact_name, test_plans=[])
         order_id = self.order_page.get_order_id()
         self.base_selenium.LOGGER.info('get the contacts to update the desired contact department')
         self.contact_page.get_contacts_page()

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -930,18 +930,17 @@ class OrdersTestCases(BaseTest):
         testunit = random.choice(testunits['testUnits'])
 
         self.order_page.get_orders_page()
-        created_order = self.order_page.create_new_order(material_type='r', article='a', contact='a', test_plans=[],
+        created_order_no = self.order_page.create_new_order(material_type='r', article='a', contact='a', test_plans=[],
                                                          test_units=[testunit['name']])
 
         self.order_page.get_orders_page()
         self.order_page.navigate_to_analysis_tab()
         self.base_selenium.LOGGER.info(
             'Assert There is an analysis for this new order.')
-        orders_analyess = self.analyses_page.search(value=created_order['orderNo'])
+        orders_analyess = self.analyses_page.search(value=created_order_no)
         latest_order_data = self.base_selenium.get_row_cells_dict_related_to_header(
             row=orders_analyess[0])
-        self.assertEqual(
-            created_order['orderNo'].replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
+        self.assertEqual(created_order_no.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
 
         self.analyses_page.open_child_table(source=orders_analyess[0])
         rows_with_childtable = self.analyses_page.result_table(element='general:table_child')
@@ -1617,18 +1616,18 @@ class OrdersTestCases(BaseTest):
 
         # Then go to the order section to create new order with this test unit
         self.order_page.get_orders_page()
-        created_order = self.order_page.create_new_order(material_type='s', article='r', contact='a',
+        created_order_no = self.order_page.create_new_order(material_type='s', article='r', contact='a',
                                                          test_units=test_units_list)
 
         # Go to the analysis section and search by the order number that created
         self.analyses_page.get_analyses_page()
         self.base_selenium.LOGGER.info(
             'Make sure there is analysis for this order number.')
-        orders_analyess = self.analyses_page.search(created_order)
+        orders_analyess = self.analyses_page.search(created_order_no)
         latest_order_data = self.base_selenium.get_row_cells_dict_related_to_header(
             row=orders_analyess[0])
         self.assertEqual(
-            created_order.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
+            created_order_no.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
 
         # Open the child table tp check the test unit display correct
         self.analyses_page.open_child_table(source=orders_analyess[0])
@@ -1653,11 +1652,11 @@ class OrdersTestCases(BaseTest):
         self.analyses_page.get_analyses_page()
         self.base_selenium.LOGGER.info(
             'Make sure there is analysis for this order number.')
-        orders_analyess = self.analyses_page.search(created_order)
+        orders_analyess = self.analyses_page.search(created_order_no)
         latest_order_data = self.base_selenium.get_row_cells_dict_related_to_header(
             row=orders_analyess[0])
         self.assertEqual(
-            created_order.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
+            created_order_no.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
 
         # Open the child table to make sure the update reflected successfully
         self.analyses_page.open_child_table(source=orders_analyess[0])
@@ -1688,18 +1687,18 @@ class OrdersTestCases(BaseTest):
 
         # Then go to the order section to create new order with this test unit
         self.order_page.get_orders_page()
-        created_order = self.order_page.create_new_order(material_type='s', article='r', contact='a',
+        created_order_no = self.order_page.create_new_order(material_type='s', article='r', contact='a',
                                                          test_units=test_units_list)
 
         # Go to the analysis section and search by the order number that created
         self.analyses_page.get_analyses_page()
         self.base_selenium.LOGGER.info(
             'Make sure there is analysis for this order number.')
-        orders_analyess = self.analyses_page.search(created_order)
+        orders_analyess = self.analyses_page.search(created_order_no)
         latest_order_data = self.base_selenium.get_row_cells_dict_related_to_header(
             row=orders_analyess[0])
         self.assertEqual(
-            created_order.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
+            created_order_no.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
 
         # Open the child table tp check the test unit display correct
         self.analyses_page.open_child_table(source=orders_analyess[0])
@@ -1726,11 +1725,11 @@ class OrdersTestCases(BaseTest):
         self.analyses_page.get_analyses_page()
         self.base_selenium.LOGGER.info(
             'Make sure there is analysis for this order number.')
-        orders_analyess = self.analyses_page.search(created_order)
+        orders_analyess = self.analyses_page.search(created_order_no)
         latest_order_data = self.base_selenium.get_row_cells_dict_related_to_header(
             row=orders_analyess[0])
         self.assertEqual(
-            created_order.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
+            created_order_no.replace("'", ""), latest_order_data['Order No.'].replace("'", ""))
 
         # Open the child table to make sure the update reflected successfully
         self.analyses_page.open_child_table(source=orders_analyess[0])


### PR DESCRIPTION
I updated : https://github.com/modeso-open-source/1lims-automation/blob/606edc47f80a8fb0b1b9bf8ec8242368f57429f6/ui_testing/pages/order_page.py#L141
to return order_no and updated all testcases upon this change.
Also, I reviewed all test cases that use : https://github.com/modeso-open-source/1lims-automation/blob/51e189768488ad36ac3ee3d9c950e1a9ce761e71/ui_testing/pages/order_page.py#L403
to make sure it uses valid return data. 
As, it was return get_suborder_data() before, and I updated it in previous PR