### PR TITLE
LIMS-4270: update_order_no_should_reflect_all_suborders_and_analysis

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_cases: ["ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test027_update_material_type_0_testPlans ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test027_update_material_type_1_testUnit"]
+        test_cases: ["ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test32_update_order_no_should_reflect_all_suborders_and_analysis"]
 
     steps:
       - uses: actions/checkout@master

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -464,43 +464,6 @@ class OrdersTestCases(BaseTest):
             self.assertEqual(
                 selected_order_data['Test Plans'], row_data['Test Plans'])
 
-    # will continue with us
-    # @skip("https://modeso.atlassian.net/browse/LIMS-4782")
-    def test013_update_order_number(self):
-        """
-        New: Orders: Table: Update order number Approach: When I update order number all suborders inside it updated it's order number,
-        and also in the analysis section.
-        LIMS-4270
-        """
-        self.base_selenium.LOGGER.info(
-            ' Running test case to check that when order no is updated, all suborders are updated')
-
-        # create order with multiple suborders
-        self.base_selenium.LOGGER.info(
-            ' Create order with 5 sub orders to make sure of the count of the created/ updated orders')
-        order_no_created = self.order_page.create_new_order(material_type='r', article='a', contact='a',
-                                                            test_plans=['a'],
-                                                            test_units=['a'], multiple_suborders=5)
-        self.base_selenium.LOGGER.info(
-            ' + orders_created_with_number : {}'.format(order_no_created))
-        order_no_created = order_no_created.replace("'", '')
-
-        # filter by the created order number and get the count
-        orders_result = self.orders_page.search(order_no_created)
-        self.base_selenium.LOGGER.info(
-            ' + filter_by_order_no : {}'.format(order_no_created))
-        orders_count = self.order_page.get_table_records()
-        self.base_selenium.LOGGER.info(
-            ' + count_of_the_created_orders : {}'.format(orders_count))
-
-        # open the last created order to update its number and checking whether it will affect the rest of the orders or not
-        self.order_page.get_random_x(row=orders_result[0])
-        new_order_no = self.order_page.generate_random_text()
-        self.order_page.set_no(no=new_order_no)
-        self.order_page.save(save_btn='order:save_btn')
-        self.base_selenium.LOGGER.info(
-            ' + order_updated_with_number : {}'.format(new_order_no))
-
     @parameterized.expand(['save_btn', 'cancel'])
     def test014_update_first_order_material_type(self, save):
         """
@@ -1924,30 +1887,26 @@ class OrdersTestCases(BaseTest):
         LIMS-4270
         """
         self.info('generate new order number to use it for update')
-        new_order_no = self.orders_api.get_auto_generated_order_no()
-        year_value = self.order_page.get_current_year()[2:]
+        new_order_no = str(self.orders_api.get_auto_generated_order_no()[0]['id'])
+        year_value = str(self.order_page.get_current_year()[2:])
         formated_order_no = new_order_no + '-' + year_value
         self.info('newly generated order number = {}'.format(formated_order_no))
-        order = self.orders_api.get_all_orders(limit=50)['orders'][1]
-        self.orders_page.get_order_edit_page_by_id(id=order['id'])
+        response, _ = self.orders_api.get_all_orders(limit=50)
+        order = random.choice(response['orders'])
+        self.orders_page.get_order_edit_page_by_id(id=order['orderId'])
         self.order_page.set_no(no=formated_order_no)
         self.order_page.sleep_small()
-        self.order_page.save(save_btn='order:save_btn', sleep=True)
-
-        self.info('refresh to make sure that data are saved correctly')
-        self.base_selenium.refresh()
+        self.order_page.save_and_wait(save_btn='order:save_btn')
         order_no_after_update = self.order_page.get_no()
-
-        self.info('order no is {}, and it should be {}'.format(order_no_after_update, formated_order_no))
-        self.assertEqual(order_no_after_update.replace("'", ""), formated_order_no)
-
+        self.info('order no is {}, and it should be {}'.format(order_no_after_update, formated_order_no+'20'))
+        self.assertEqual(order_no_after_update.replace("'", ""), formated_order_no+'20')
         self.info('navigate to analysis tab to make sure that order no updated correctly')
-        self.order_page.navigate_to_analysis_tab()
-        analysis_records = self.single_analysis_page.get_all_analysis_records()
-
+        self.orders_page.get_orders_page()
+        self.orders_page.navigate_to_analysis_active_table()
+        self.analyses_page.search(formated_order_no+'20')
+        analysis_record = self.single_analysis_page.get_the_latest_row_data()
         self.info('checking order no of each analysis')
-        for record in analysis_records:
-            self.assertEqual(record['Order No.'], formated_order_no)
+        self.assertEqual(analysis_record['Order No.'], formated_order_no+'20')
 
     def test033_Duplicate_main_order_and_cahange_materiel_type(self):
         """


### PR DESCRIPTION
I removed update_order_no_should_reflect_all_suborders_and_analysis
and updated original function 
```
➜  1lims-automation git:(LIMS-4270) ✗ nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test06_orders.py:OrdersTestCases.test32_update_order_no_should_reflect_all_suborders_and_analysis
2020-06-16 16:39:41.322 | INFO     | api_testing.apis.base_api:info:93 - Get authorized api session.
2020-06-16 16:39:41.323 | INFO     | api_testing.apis.base_api:info:93 - admin:admin
2020-06-16 16:39:42.005 | INFO     | api_testing.apis.base_api:info:93 - session ID : 0uRYGB8XClA5s-R6l7cHDYYFoWGxwrKxRYtTQ4Vi91Y .....
In case I update the order number of record that has multiple suborders inside it ...   
2020-06-16 16:39:42.438 | INFO     | ui_testing.testcases.base_test:info:134 - Test case : test32_update_order_no_should_reflect_all_suborders_and_analysis
2020-06-16 16:40:02.222 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:524 - wait until page is loaded
2020-06-16 16:40:03.562 | INFO     | api_testing.apis.base_api:info:93 - set order configuration
2020-06-16 16:40:04.669 | INFO     | api_testing.apis.base_api:info:93 - status code: 1
2020-06-16 16:40:04.669 | INFO     | ui_testing.testcases.base_test:info:134 - generate new order number to use it for update
2020-06-16 16:40:04.670 | INFO     | api_testing.apis.base_api:info:93 - GET : https://automation.1lims.com/api/orders/auto/generatedId
2020-06-16 16:40:05.282 | INFO     | api_testing.apis.base_api:info:93 - Status code: 1
2020-06-16 16:40:05.283 | INFO     | ui_testing.testcases.base_test:info:134 - newly generated order number = 84883-20
2020-06-16 16:40:05.283 | INFO     | api_testing.apis.base_api:info:93 - GET : https://automation.1lims.com/api/orders
2020-06-16 16:40:05.822 | INFO     | api_testing.apis.base_api:info:93 - Status code: 1
2020-06-16 16:40:07.354 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:524 - wait until page is loaded
2020-06-16 16:40:09.016 | INFO     | ui_testing.pages.base_pages:info:277 -  set no. 84883-20
2020-06-16 16:40:09.287 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-06-16 16:40:14.293 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-06-16 16:40:19.299 | INFO     | ui_testing.pages.base_pages:info:277 -  save the changes
2020-06-16 16:40:19.300 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-06-16 16:40:21.549 | INFO     | ui_testing.pages.base_pages:sleep_tiny:39 -  Tiny sleep.
2020-06-16 16:40:23.550 | INFO     | ui_testing.pages.base_pages:info:277 -  refresh to make sure that data are saved correctly
2020-06-16 16:40:30.111 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:524 - wait until page is loaded
2020-06-16 16:40:30.192 | INFO     | ui_testing.testcases.base_test:info:134 - order no is 84'883-2'020, and it should be 84883-2020
2020-06-16 16:40:30.193 | INFO     | ui_testing.testcases.base_test:info:134 - navigate to analysis tab to make sure that order no updated correctly
2020-06-16 16:40:31.770 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:524 - wait until page is loaded
2020-06-16 16:40:34.710 | INFO     | ui_testing.pages.base_pages:sleep_small:43 -  Small sleep.
2020-06-16 16:40:53.295 | INFO     | ui_testing.testcases.base_test:info:134 - checking order no of each analysis
2020-06-16 16:40:53.369 | INFO     | ui_testing.testcases.base_test:info:134 - TearDown.        
ok

----------------------------------------------------------------------
Ran 1 test in 70.932s

OK

```