### PR TITLE
LIMS-5354: Main order only appears in active table

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: execute test case in parallel
         env:
-          TEST_FILE: ui_testing/testcases/header_tests/test08_usermanagement.py
+          TEST_FILE: ui_testing/testcases/basic_tests/test06_orders.py
           TEST_REG: test[0-9]{3}
         run: docker container run -t --shm-size=2g -v `pwd`:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=${{ strategy.job-total }} NODE_INDEX=${{ matrix.test_cases }} nosetests -vs --nologcapture --tc-file=config.ini --tc=browser.headless:True  --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A 'not series' -m '$TEST_REG' $TEST_FILE"
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       - name: execute test case in parallel
         env:
           TEST_FILE: ui_testing/testcases/basic_tests/test06_orders.py
-          TEST_REG: test[0-9]{3}
+          TEST_REG: test066
         run: docker container run -t --shm-size=2g -v `pwd`:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=${{ strategy.job-total }} NODE_INDEX=${{ matrix.test_cases }} nosetests -vs --nologcapture --tc-file=config.ini --tc=browser.headless:True  --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A 'not series' -m '$TEST_REG' $TEST_FILE"
 
 #  test_pull_request_in_series:

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -680,3 +680,12 @@ class Order(Orders):
         self.sleep_small()
         self.info('get test unit suggestion list')
         test_units = self.base_selenium.get_drop_down_suggestion_list(element='order:test_unit',item_text=test_unit_name)
+
+    def get_table_with_add(self):
+        table = self.base_selenium.find_element(element='order:suborder_table')
+        return table
+
+    def check_suborders_appear(self):
+        is_suborder_exist = self.base_selenium.check_element_is_exist(
+            element='table_element=general:table_child')
+        return is_suborder_exist

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -2296,3 +2296,36 @@ class OrdersTestCases(BaseTest):
                                   f"{str(fixed_sheet_row_data)} : {str(formatted_orders[index])}")
             for item in formatted_orders[index]:
                 self.assertIn(item, fixed_sheet_row_data)
+
+    @skip("https://modeso.atlassian.net/browse/LIMSA-236")
+    def test066_main_orders_only_should_be_displayed_in_the_orders_list(self):
+        """
+        Make sure that user sees the main orders only in the order list
+
+        LIMS-5354
+        """
+        self.info('assert active table is displayed')
+        table_records_count = len(self.order_page.result_table())
+        self.assertGreater(table_records_count, 0)
+        self.info('There is no duplications in the orders numbers')
+        orders, _ = self.orders_api.get_all_orders(limit=20)
+        order = random.choice(orders['orders'])
+        order_no = order['orderNo']
+        self.orders_page.search(order_no)
+        table_duplicate_records = len(self.order_page.result_table())
+        self.assertEqual(1, table_duplicate_records)
+        self.info('click on the random order from the list, Order table with add will be opened')
+        self.orders_page.get_order_edit_page_by_id(order['id'])
+        table_with_add = self.order_page.get_table_with_add()
+        self.assertIsNotNone(table_with_add)
+        self.info('duplicate the first suborder')
+        self.order_page.duplicate_from_table_view()
+        self.info('click on save button')
+        self.order_page.save(save_btn='order:save_btn')
+        self.assertEqual(self.base_selenium.get_text(element='general:alert_confirmation'),
+                         'Successfully Updated')
+        self.info('Go back to the active table')
+        self.order_page.get_orders_page()
+        self.orders_page.search(order_no)
+        self.info('assert main order only displayed no duplicated rows for the suborders')
+        self.assertFalse(self.order_page.check_suborders_appear())


### PR DESCRIPTION
Make sure that user sees the main orders only in the order list
![Capture](https://user-images.githubusercontent.com/44288293/89784370-d48e1200-db18-11ea-9e68-e27db8ca6e53.PNG)
