### PR TITLE
LIMS-6675 : In case the unit field with sub & super, allow this to di…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_cases: [0, 1, 2, 3]
+        test_cases: [0]
 
     steps:
       - uses: actions/checkout@master
@@ -20,8 +20,8 @@ jobs:
 
       - name: execute test case in parallel
         env:
-          TEST_FILE: ui_testing/testcases/header_tests/test08_usermanagement.py
-          TEST_REG: test[0-9]{3}
+          TEST_FILE: ui_testing/testcases/basic_tests/test06_orders.py
+          TEST_REG: test066
         run: docker container run -t --shm-size=2g -v `pwd`:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=${{ strategy.job-total }} NODE_INDEX=${{ matrix.test_cases }} nosetests -vs --nologcapture --tc-file=config.ini --tc=browser.headless:True  --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A 'not series' -m '$TEST_REG' $TEST_FILE"
 
 #  test_pull_request_in_series:

--- a/api_testing/apis/test_unit_api.py
+++ b/api_testing/apis/test_unit_api.py
@@ -185,6 +185,7 @@ class TestUnitAPIFactory(BaseAPI):
         api = '{}{}'.format(self.url, self.END_POINTS['test_unit_api']['create_testunit'])
         return api, payload
 
+
     @api_factory('post')
     def create_quantitative_testunit(self, **kwargs):
         """

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -680,3 +680,22 @@ class Order(Orders):
         self.sleep_small()
         self.info('get test unit suggestion list')
         test_units = self.base_selenium.get_drop_down_suggestion_list(element='order:test_unit',item_text=test_unit_name)
+
+
+
+    def create_new_order_get_test_unit_suggetion_list(self, material_type='', test_unit_name=' ') :
+        self.info(' Create new order.')
+        self.click_create_order_button()
+        self.sleep_small()
+        self.set_new_order()
+        self.set_contact(contact='')
+        self.sleep_tiny()
+        self.set_material_type(material_type=material_type)
+        self.sleep_small()
+        self.set_article(article='')
+        self.sleep_small()
+        self.info('get test unit suggestion list')
+        test_units = self.base_selenium.get_drop_down_suggestion_list(element='order:test_unit',
+                                                                      item_text=test_unit_name)
+        return test_units
+

--- a/ui_testing/pages/order_page.py
+++ b/ui_testing/pages/order_page.py
@@ -668,20 +668,6 @@ class Order(Orders):
             results.append({'test_plan': test_plan, 'test_units': test_units})
         return results
 
-    def create_new_order_get_test_unit_suggetion_list(self, material_type, test_unit_name):
-        self.info(' Create new order.')
-        self.click_create_order_button()
-        self.set_new_order()
-        self.set_contact(contact='')
-        self.sleep_small()
-        self.set_material_type(material_type=material_type)
-        self.sleep_small()
-        self.set_article(article='')
-        self.sleep_small()
-        self.info('get test unit suggestion list')
-        test_units = self.base_selenium.get_drop_down_suggestion_list(element='order:test_unit',item_text=test_unit_name)
-
-
 
     def create_new_order_get_test_unit_suggetion_list(self, material_type='', test_unit_name=' ') :
         self.info(' Create new order.')
@@ -698,4 +684,3 @@ class Order(Orders):
         test_units = self.base_selenium.get_drop_down_suggestion_list(element='order:test_unit',
                                                                       item_text=test_unit_name)
         return test_units
-

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -297,5 +297,4 @@ class Orders(BasePages):
             if value in results[0].text:
                 return True
             else:
-                return False 
-
+                return False

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -25,8 +25,6 @@ class OrdersTestCases(BaseTest):
     def setUp(self):
         super().setUp()
         self.order_page = Order()
-        self.test_units_page = TstUnits()
-        self.test_unit_page=TstUnit()
         self.orders_api = OrdersAPI()
         self.testplan_page = TstPlan()
         self.orders_page = Orders()
@@ -2309,7 +2307,8 @@ class OrdersTestCases(BaseTest):
         allow this to display in the unit field drop down list in the analysis form
         LIMS-6675
         """
-
+        self.test_units_page = TstUnits()
+        self.test_unit_page = TstUnit()
         self.test_units_page.get_test_units_page()
         self.test_units_page.open_configurations()
         self.test_units_page.open_testunit_name_configurations_options()
@@ -2330,6 +2329,3 @@ class OrdersTestCases(BaseTest):
         self.order_page.get_orders_page()
         unit=self.order_page.create_new_order_get_test_unit_suggetion_list(material_type='',test_unit_name='m[g]{o}')
         self.assertIn("m[g]{o}",unit)
-
-
-

--- a/ui_testing/testcases/basic_tests/test06_orders.py
+++ b/ui_testing/testcases/basic_tests/test06_orders.py
@@ -14,6 +14,9 @@ from api_testing.apis.test_plan_api import TestPlanAPI
 from ui_testing.pages.testplan_page import TstPlan
 from api_testing.apis.general_utilities_api import GeneralUtilitiesAPI
 from ui_testing.pages.contacts_page import Contacts
+from ui_testing.pages.testunits_page import TstUnits
+from ui_testing.pages.testunit_page import TstUnit
+
 from random import randint
 import random
 
@@ -22,6 +25,8 @@ class OrdersTestCases(BaseTest):
     def setUp(self):
         super().setUp()
         self.order_page = Order()
+        self.test_units_page = TstUnits()
+        self.test_unit_page=TstUnit()
         self.orders_api = OrdersAPI()
         self.testplan_page = TstPlan()
         self.orders_page = Orders()
@@ -2296,3 +2301,35 @@ class OrdersTestCases(BaseTest):
                                   f"{str(fixed_sheet_row_data)} : {str(formatted_orders[index])}")
             for item in formatted_orders[index]:
                 self.assertIn(item, fixed_sheet_row_data)
+
+    @parameterized.expand(['Quantitative' ])
+    def test066_test_unit_with_sub_and_super_unit_name_appears_in_unit_field_drop_down(self, type) :
+        """
+        New: Test unit: Export: In case the unit field with sub & super,
+        allow this to display in the unit field drop down list in the analysis form
+        LIMS-6675
+        """
+
+        self.test_units_page.get_test_units_page()
+        self.test_units_page.open_configurations()
+        self.test_units_page.open_testunit_name_configurations_options()
+        self.test_units_page.select_option_to_view_search_with(view_search_options=['Unit'])
+
+        if type == 'Quantitative':
+            self.info('Create new Quantitative testunit')
+            response, payload = self.test_unit_api.create_quantitative_testunit(unit='m[g]{o}')
+        elif type =='Qualitative':
+            self.info('Create new Qualitative testunit')
+            response, payload = self.test_unit_api.create_qualitative_testunit(unit='m[g]{o}')
+        else:
+            self.info('Create new Quantitative MiBi testunit')
+            response, payload = self.test_unit_api.create_mibi_testunit(unit='m[g]{o}')
+
+        self.assertEqual(response['status'], 1, 'test unit not created {}'.format(payload))
+        self.info('go to orders page')
+        self.order_page.get_orders_page()
+        unit=self.order_page.create_new_order_get_test_unit_suggetion_list(material_type='',test_unit_name='m[g]{o}')
+        self.assertIn("m[g]{o}",unit)
+
+
+


### PR DESCRIPTION
```
D:\1lims-automation> nosetests -vs -m test066 --logging-level=WARNING ui_testing/testcases/basic_tests/test06_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-08-12 20:14:20.748 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-08-12 20:14:20.752 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-08-12 20:14:21.700 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : FlXWS-PvgWVLwf-bWAsgH6nvLgjoqI4wVUKySfqDfUU .....

DevTools listening on ws://127.0.0.1:55372/devtools/browser/7a088425-95ca-464e-851e-5e6d9f9ae829
New: Test unit: Export: In case the unit field with sub & super, [with type='Quantitative'] ...
2020-08-12 20:15:34.893 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test066_test_unit_with_sub_and_super_unit_name_appears_in_unit_field_drop_down_0_Quantitative
2020-08-12 20:15:41.036 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:562 - wait until page is loaded
2020-08-12 20:15:41.084 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:15:42.012 | INFO     | api_testing.apis.orders_api:set_configuration:395 - set order configuration
2020-08-12 20:15:43.436 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-08-12 20:15:43.444 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
2020-08-12 20:15:48.317 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:562 - wait until page is loaded
2020-08-12 20:15:48.374 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:15:49.503 | INFO     | ui_testing.pages.testunits_page:open_configurations:94 - open testunits configurations
2020-08-12 20:15:49.975 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:15:51.680 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:15:55.458 | INFO     | ui_testing.pages.testunits_page:open_testunit_name_configurations_options:102 - open testunits name configurations options
2020-08-12 20:15:55.482 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:15:57.431 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:15:59.136 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:00.303 | INFO     | ui_testing.pages.testunits_page:clear_all_selected_view_and_search_options:111 - clear selected view and search options of testunits name
2020-08-12 20:16:00.499 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:09.565 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:16:12.268 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:16:18.607 | INFO     | ui_testing.testcases.basic_tests.test06_orders:test066_test_unit_with_sub_and_super_unit_name_appears_in_unit_field_drop_down:2319 - Create new Quantitative testunit
2020-08-12 20:16:18.615 | INFO     | api_testing.apis.base_api:wrapper:122 - GET : https://automation.1lims.com/api/testUnits
2020-08-12 20:16:19.746 | INFO     | api_testing.apis.base_api:wrapper:129 - Status code: 1
2020-08-12 20:16:19.754 | INFO     | ui_testing.testcases.basic_tests.test06_orders:test066_test_unit_with_sub_and_super_unit_name_appears_in_unit_field_drop_down:2329 - go to orders page
2020-08-12 20:16:23.525 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:562 - wait until page is loaded
2020-08-12 20:16:25.069 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:26.171 | INFO     | ui_testing.pages.order_page:create_new_order_get_test_unit_suggetion_list:687 -  Create new order.
2020-08-12 20:16:26.175 | INFO     | ui_testing.pages.orders_page:click_create_order_button:21 - Press create order button
2020-08-12 20:16:26.911 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:562 - wait until page is loaded
2020-08-12 20:16:27.720 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:29.411 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:16:31.881 | INFO     | ui_testing.pages.order_page:set_new_order:18 - Set new order.
2020-08-12 20:16:45.932 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:55.384 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:16:57.803 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:17:05.786 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-12 20:17:07.710 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-08-12 20:17:10.211 | INFO     | ui_testing.pages.order_page:create_new_order_get_test_unit_suggetion_list:697 - get test unit suggestion list
2020-08-12 20:17:16.257 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-08-12 20:17:18.841 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 178.634s

OK


```