### PR TITLE
commit

### DIFF
--- a/ui_testing/testcases/basic_tests/test004_testunits.py
+++ b/ui_testing/testcases/basic_tests/test004_testunits.py
@@ -631,7 +631,8 @@ class TestUnitsTestCases(BaseTest):
     @parameterized.expand([('unitsub', 'qualitative'),
                            ('unitsub', 'quantitative'),
                            ('unitsuper', 'qualitative'),
-                           ('unitsuper', 'quantitative')])
+                           ('unitsuper', 'quantitative'),
+                          ])
     def test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet(self, unit_with_sub_or_super, type):
         """
         New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the
@@ -652,7 +653,10 @@ class TestUnitsTestCases(BaseTest):
         Test unit: Export: Sub & Super scripts Approach:  Allow user to see the sub &
         super scripts in the export file
 
-        LIMS-5809
+        LIMS-5810
+
+        Test unit: Export: Sub & Super scripts Approach: Allow user to see the sub
+         & super scripts in the export file ( quantitative MiBi )
         """
         if unit_with_sub_or_super == 'unitsub' and type == 'qualitative':
             response, payload = self.test_unit_api.create_qualitative_testunit(unit='[sub]')
@@ -666,6 +670,7 @@ class TestUnitsTestCases(BaseTest):
         else:
             response, payload = self.test_unit_api.create_quantitative_testunit(unit='{super}')
             preview_unit = 'super'
+
 
         self.assertEqual(response['status'], 1, 'test unit not createed {}'.format(payload))
         self.test_unit_page.apply_filter_scenario(


### PR DESCRIPTION
D:\1lims-automation> nosetests -vs -m test024 --logging-level=WARNING ui_testing/testcases/basic_tests/test004_testunits.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-08-18 15:14:43.368 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-08-18 15:14:43.382 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - root:root
2020-08-18 15:14:44.391 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : nqgpFQIgyPewExJl-hCByf9Fni6BTTRwxGjfanGYXsg .....

DevTools listening on ws://127.0.0.1:65045/devtools/browser/56b2f1c8-24e5-4af0-add7-857590b8c149
New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsub', type='qualitative'] ...
2020-08-18 15:15:50.399 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_0_unitsub
2020-08-18 15:15:50.476 | INFO     | api_testing.apis.test_unit_api:set_configuration:407 - set test unit configuration
2020-08-18 15:15:51.388 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-08-18 15:15:51.408 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
2020-08-18 15:16:16.214 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:16:16.418 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:16:18.748 | INFO     | api_testing.apis.base_api:wrapper:122 - GET : https://automation.1lims.com/api/testUnits
2020-08-18 15:16:20.519 | INFO     | api_testing.apis.base_api:wrapper:129 - Status code: 1
2020-08-18 15:16:20.533 | INFO     | ui_testing.pages.base_pages:open_filter_menu:85 - open Filter
2020-08-18 15:16:22.018 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:16:29.676 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:16:29.860 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:16:32.176 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:229 - download XSLX sheet
2020-08-18 15:17:05.360 | INFO     | ui_testing.testcases.basic_tests.test004_testunits:test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet:681 - Comparing the unit name in test unit table
2020-08-18 15:17:05.405 | INFO     | ui_testing.testcases.base_test:screen_shot:46 - saved error screen shot : ./screenshots/screenshot_test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_0_unit
sub_.png
2020-08-18 15:17:06.647 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-08-18 15:17:17.642 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
FAIL
New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsub', type='quantitative'] ...
2020-08-18 15:17:17.711 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_1_unitsub
2020-08-18 15:17:17.793 | INFO     | api_testing.apis.test_unit_api:set_configuration:407 - set test unit configuration
2020-08-18 15:17:18.798 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-08-18 15:17:18.814 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
2020-08-18 15:17:54.561 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:17:55.009 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:17:57.917 | INFO     | api_testing.apis.base_api:wrapper:122 - GET : https://automation.1lims.com/api/testUnits
2020-08-18 15:17:58.500 | INFO     | api_testing.apis.base_api:wrapper:129 - Status code: 1
2020-08-18 15:17:58.524 | INFO     | ui_testing.pages.base_pages:open_filter_menu:85 - open Filter
2020-08-18 15:18:00.174 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:18:08.715 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:18:08.936 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:18:11.477 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:229 - download XSLX sheet
2020-08-18 15:18:44.246 | INFO     | ui_testing.testcases.basic_tests.test004_testunits:test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet:681 - Comparing the unit name in test unit table
2020-08-18 15:18:44.262 | INFO     | ui_testing.testcases.base_test:screen_shot:46 - saved error screen shot : ./screenshots/screenshot_test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_1_unit
sub_.png
2020-08-18 15:18:45.731 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-08-18 15:19:00.632 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
FAIL
New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsuper', type='qualitative'] ...
2020-08-18 15:19:00.836 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_2_unitsuper
2020-08-18 15:19:00.979 | INFO     | api_testing.apis.test_unit_api:set_configuration:407 - set test unit configuration
2020-08-18 15:19:02.071 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-08-18 15:19:02.086 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
2020-08-18 15:19:38.725 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:19:38.970 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:19:41.900 | INFO     | api_testing.apis.base_api:wrapper:122 - GET : https://automation.1lims.com/api/testUnits
2020-08-18 15:19:42.504 | INFO     | api_testing.apis.base_api:wrapper:129 - Status code: 1
2020-08-18 15:19:42.516 | INFO     | ui_testing.pages.base_pages:open_filter_menu:85 - open Filter
2020-08-18 15:19:43.772 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:19:51.574 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:568 - wait until page is loaded
2020-08-18 15:19:51.792 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-08-18 15:19:54.832 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:229 - download XSLX sheet
2020-08-18 15:20:36.310 | INFO     | ui_testing.testcases.basic_tests.test004_testunits:test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet:681 - Comparing the unit name in test unit table
2020-08-18 15:20:36.542 | INFO     | ui_testing.testcases.base_test:screen_shot:46 - saved error screen shot : ./screenshots/screenshot_test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_2_unit
super_.png
2020-08-18 15:20:39.775 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-08-18 15:21:16.712 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
FAIL
New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsuper', type='quantitative'] ...
2020-08-18 15:21:16.759 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet_3_unitsuper
2020-08-18 15:21:17.152 | INFO     | api_testing.apis.test_unit_api:set_configuration:407 - set test unit configuration
2020-08-18 15:21:18.061 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-08-18 15:21:18.101 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
ERROR

======================================================================
ERROR: New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsuper', type='quantitative']
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test004_testunits.py", line 28, in setUp
    self.test_unit_page.get_test_units_page()
  File "D:\1lims-automation\ui_testing\pages\testunits_page.py", line 12, in get_test_units_page
    self.base_selenium.get(url=self.test_units_url)
  File "D:\1lims-automation\ui_testing\pages\base_selenium.py", line 191, in get
    self.driver.get(url)
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\selenium\webdriver\remote\webdriver.py", line 333, in get
    self.execute(Command.GET, {'url': url})
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\selenium\webdriver\remote\webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\selenium\webdriver\remote\errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.WebDriverException: Message: disconnected: Unable to receive message from renderer
  (Session info: chrome=84.0.4147.125)


======================================================================
FAIL: New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsub', type='qualitative']
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\parameterized\parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test004_testunits.py", line 683, in test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet
    self.assertIn(preview_unit, fixed_row_data)
AssertionError: 'sub' not found in ['aabcdb92cd', 'd8c19881af', 'a399c18c04', 'All', '9c31099b85', '1', 'All', '9c31099b85']

======================================================================
FAIL: New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsub', type='quantitative']
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\parameterized\parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test004_testunits.py", line 683, in test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet
    self.assertIn(preview_unit, fixed_row_data)
AssertionError: 'sub' not found in ['2d5f59b993', '10-57', '5b388e5c1e', 'All', '9ef707b604', '1', 'All', '9ef707b604']

======================================================================
FAIL: New: Test unit: Export: Sub & Super scripts Approach: Allow user to see the [with unit_with_sub_or_super='unitsuper', type='qualitative']
----------------------------------------------------------------------
Traceback (most recent call last):
  File "c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\parameterized\parameterized.py", line 392, in standalone_func
    return func(*(a + p.args), **p.kwargs)
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test004_testunits.py", line 683, in test024_test_unit_with_sub_and_super_scripts_appears_in_exported_sheet
    self.assertIn(preview_unit, fixed_row_data)
AssertionError: 'super' not found in ['9c164d3c45', 'b2acb4757c', 'eb413f9982', 'All', 'effa525372', '1', 'All', 'effa525372']

----------------------------------------------------------------------
Ran 4 tests in 422.743s

FAILED (errors=1, failures=3)

D:\1lims-automation>
