### PR TITLE
 LIMS-5794: Active table/unit: Sub & Super scripts: Allow unit to display with sub & super scripts in the active table         

### DIFF
--- a/ui_testing/testcases/basic_tests/test004_testunits.py
+++ b/ui_testing/testcases/basic_tests/test004_testunits.py
@@ -1312,3 +1312,27 @@ class TestUnitsTestCases(BaseTest):
         self.test_units_page.sleep_tiny()
         test_unit_found = self.test_units_page.filter_by_user_get_result(payload['username'])
         self.assertTrue(test_unit_found)
+
+    def test050_sub_and_super_scripts_in_active_table(self) :
+        """
+        New: Test units: Active table/unit: Sub & Super scripts: Allow unit to display with sub & super scripts in the active table
+
+        LIMS-5794
+        """
+        self.info('Create new Qualitative testunit')
+        response, payload = self.test_unit_api.create_qualitative_testunit(unit='m[g]{o}')
+        self.assertEqual(response['status'], 1, 'test unit not created {}'.format(payload))
+        self.test_unit_page.click_overview()
+        self.test_units_page.sleep_tiny()
+        data = self.test_unit_page.filter_and_get_result(text=response['testUnit']['No'])
+        #print(data['Unit'])
+        #print(payload['unit'])
+        self.assertEqual(payload['unit'],data['Unit'])
+
+
+
+        #print(payload)
+        #print(response['testUnit']['No'])
+
+
+       


### PR DESCRIPTION
FAIL: New: Test units: Active table/unit: Sub & Super scripts: Allow unit to display with sub & super scripts in the active table
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test004_testunits.py", line 1330, in test050_sub_and_super_scripts_in_active_table
    self.assertEqual(payload['unit'],data['Unit'])
AssertionError: 'm[g]{o}' != 'mgo'
- m[g]{o}
+ mgo


