### PR TITLE
LIMS-7411 and 7444: test unit configuration affect on order filter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,10 @@
-#name: CI
-#
-#on:
-#  pull_request:
-#    branches: [ master ]
-#
-#jobs:
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
 #  test_pull_request_in_parallel:
 #    runs-on: ubuntu-20.04
 #    strategy:
@@ -20,23 +20,23 @@
 #
 #      - name: parallel execution for each module
 #        run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
-#
-#  test_pull_request_in_series:
-#    runs-on: ubuntu-20.04
+
+  test_pull_request_in_series:
+    runs-on: ubuntu-20.04
 #    needs: test_pull_request_in_parallel
-#    if: always()
-#    strategy:
-#      fail-fast: false
-#
-#    steps:
-#      - uses: actions/checkout@master
-#
-#      - name: pull docker image
-#        run:  docker pull 0xislamtaha/seleniumchromenose:83
-#
-#      - name: sequal execution for series
-#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
-#
+    if: always()
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: pull docker image
+        run:  docker pull 0xislamtaha/seleniumchromenose:83
+
+      - name: sequal execution for series
+        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
+
 #  merge_launches:
 #    runs-on: ubuntu-20.04
 #    needs: [test_pull_request_in_parallel, test_pull_request_in_series]

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -1,55 +1,47 @@
-##!/bin/bash
-#
-#EXECUTION_FILES=(
-#    ui_testing/testcases/basic_tests/test002_articles.py
-#    ui_testing/testcases/basic_tests/test003_testplans.py
-#    ui_testing/testcases/basic_tests/test004_testunits.py
-#    ui_testing/testcases/basic_tests/test005_contacts.py
-#    ui_testing/testcases/header_tests/test007_audit_trail.py
-#    ui_testing/testcases/header_tests/test008_company_profile.py
-#    ui_testing/testcases/header_tests/test009_usermanagement.py
-#    ui_testing/testcases/header_tests/test010_my_profile.py
-#    ui_testing/testcases/header_tests/test011_rolesandpermissions.py
-#  )
-#
-#TEST_REG='test[0-9]{3}'
-#
-#
-#NODE_TOTAL=$1;
-#NODE_INDEX=$2;
-#RUN_REF=$3;
-#RUN_ID=$4;
-#RUN_NUMBER=$5;
-#WORK_DIR=$6;
-#ATTR=$7;
-#UUID=$8;
-#
-#echo 'NODE_TOTAL: ' $NODE_TOTAL;
-#echo 'NODE_INDEX: ' $NODE_INDEX;
-#echo 'TEST_REG: ' $TEST_REG;
-#echo 'RUN_REF: ' $RUN_REF;
-#echo 'RUN_ID: ' $RUN_ID;
-#echo 'RUN_NUMBER: ' $RUN_NUMBER;
-#echo 'WORK_DIR: ' $WORK_DIR;
-#EXECUTION_RESULT=()
-#
-#for TEST_FILE in "${EXECUTION_FILES[@]}"
-# do
-#   echo 'TEST_FILE: ' $TEST_FILE;
-#   if [[ $ATTR = "not series" ]]
-#    then
-#      docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=$NODE_TOTAL NODE_INDEX=$NODE_INDEX nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
-#      EXECUTION_RESULT+=($?)
-#    else
-#      docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
-#      EXECUTION_RESULT+=($?)
-#   fi
-# done
-#
-#for exit_code in "${EXECUTION_RESULT[@]}"
-#do
-#  if [[ $exit_code = 1 ]]
-#  then
-#    exit 1;
-#  fi
-#done
+#!/bin/bash
+
+EXECUTION_FILES=(
+    ui_testing/testcases/basic_tests/test006_orders.py
+  )
+
+TEST_REG='test100'
+
+
+NODE_TOTAL=$1;
+NODE_INDEX=$2;
+RUN_REF=$3;
+RUN_ID=$4;
+RUN_NUMBER=$5;
+WORK_DIR=$6;
+ATTR=$7;
+UUID=$8;
+
+echo 'NODE_TOTAL: ' $NODE_TOTAL;
+echo 'NODE_INDEX: ' $NODE_INDEX;
+echo 'TEST_REG: ' $TEST_REG;
+echo 'RUN_REF: ' $RUN_REF;
+echo 'RUN_ID: ' $RUN_ID;
+echo 'RUN_NUMBER: ' $RUN_NUMBER;
+echo 'WORK_DIR: ' $WORK_DIR;
+EXECUTION_RESULT=()
+
+for TEST_FILE in "${EXECUTION_FILES[@]}"
+ do
+   echo 'TEST_FILE: ' $TEST_FILE;
+   if [[ $ATTR = "not series" ]]
+    then
+      docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=$NODE_TOTAL NODE_INDEX=$NODE_INDEX nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
+      EXECUTION_RESULT+=($?)
+    else
+      docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
+      EXECUTION_RESULT+=($?)
+   fi
+ done
+
+for exit_code in "${EXECUTION_RESULT[@]}"
+do
+  if [[ $exit_code = 1 ]]
+  then
+    exit 1;
+  fi
+done

--- a/api_testing/apis/test_unit_api.py
+++ b/api_testing/apis/test_unit_api.py
@@ -224,6 +224,7 @@ class TestUnitAPIFactory(BaseAPI):
             'quantificationUpperLimit': '',
             'quantificationLowerLimit': '',
             'useSpec': True,
+            'unit': '',
             'iterations': '1',
             "roundingOption": {"id": 0, "text": "No Rounding"}
         }

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3256,7 +3256,6 @@ class OrdersTestCases(BaseTest):
         self.orders_page.get_orders_page()
         self.orders_page.sleep_tiny()
         self.orders_page.open_filter_menu()
-        self.orders_page.sleep_tiny()
         self.base_selenium.wait_element(element='orders:test_units_filter')
         self.orders_page.filter_by(filter_element='orders:test_units_filter', filter_text=filter_text)
         found_filter_text = self.base_selenium.get_text('orders:test_units_filter').replace("\n×", "")
@@ -3268,7 +3267,7 @@ class OrdersTestCases(BaseTest):
             self.assertEqual(found_filter_text, filter_text)
 
         self.orders_page.filter_apply()
-        self.orders_page.close_filter_menu()
+        self.orders_page.sleep_tiny()
         results = self.order_page.result_table()
         self.assertGreaterEqual(len(results), 1)
         for i in range(len(results) - 1):
@@ -3281,6 +3280,3 @@ class OrdersTestCases(BaseTest):
             self.assertTrue(key_found)
             # close child table
             self.orders_page.close_child_table(source=results[i])
-
-
-

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -2624,6 +2624,7 @@ class OrdersTestCases(BaseTest):
          Make sure that user can filter by sub & super scripts in the filter drop down list
 
          LIMS-7447
+         LIMS-7444
         """
         self.test_unit_api = TestUnitAPI()
         self.test_unit_api.set_name_configuration()
@@ -3213,5 +3214,73 @@ class OrdersTestCases(BaseTest):
             if result['test_plan'] == testPlan['testPlan']['text']:
                 for testunit in testunit_names:
                     self.assertIn(testunit, result['test_units'])
+
+    @parameterized.expand([('Name', 'Type'),
+                           ('Unit', 'No'),
+                           ('Quantification Limit', '')])
+    @attr(series=True)
+    def test100_test_unit_name_allow_user_to_filter_with_selected_two_options_order(self, search_view_option1,
+                                                                                    search_view_option2):
+        """
+         Orders: Filter test unit Approach: Allow the search criteria in
+         the drop down list in the filter section to be same as in the form
+
+         LIMS-7411
+        """
+        self.test_units_page = TstUnits()
+        self.test_units_page.get_test_units_page()
+        self.test_units_page.open_configurations()
+        self.test_units_page.open_testunit_name_configurations_options()
+        self.test_units_page.select_option_to_view_search_with(
+            view_search_options=[search_view_option1, search_view_option2])
+
+        upperLimit = self.generate_random_number(lower=50, upper=100)
+        lowerLimit = self.generate_random_number(lower=1, upper=49)
+        self.info('Create new quantitative test unit with unit and quantification')
+        response, payload = self.test_unit_api.create_quantitative_testunit(
+            useSpec=False, useQuantification=True, quantificationUpperLimit=upperLimit,
+            quantificationLowerLimit=lowerLimit, unit='m[g]{o}')
+        self.assertEqual(response['status'], 1, payload)
+        formated_tu, _ = TestUnitAPI().get_testunit_form_data(response['testUnit']['testUnitId'])
+        test_unit = [{'id': formated_tu['testUnit']['id'], 'name': formated_tu['testUnit']['name']}]
+        self.info('create new order created test unit number'.format(payload))
+        res, order = self.orders_api.create_new_order(testUnits=test_unit)
+        self.assertEqual(res['status'], 1, 'order not created with {}'.format(order))
+        if search_view_option1 == 'Name' and search_view_option2 == 'Type':
+            filter_text = payload['name']
+        elif search_view_option1 == 'Unit' and search_view_option2 == 'No':
+            filter_text = str(payload['number'])
+        else:
+            filter_text = str(payload['quantificationLowerLimit']) + '-' + str(payload['quantificationUpperLimit'])
+
+        self.orders_page.get_orders_page()
+        self.orders_page.sleep_tiny()
+        self.orders_page.open_filter_menu()
+        self.orders_page.sleep_tiny()
+        self.base_selenium.wait_element(element='orders:test_units_filter')
+        self.orders_page.filter_by(filter_element='orders:test_units_filter', filter_text=filter_text)
+        found_filter_text = self.base_selenium.get_text('orders:test_units_filter').replace("\n×", "")
+        if search_view_option1 == 'Name' and search_view_option2 == 'Type':
+            self.assertEqual(found_filter_text, payload['name'] + ': Quantitative')
+        elif search_view_option1 == 'Unit' and search_view_option2 == 'No':
+            self.assertEqual(found_filter_text, 'm[g]{o}: ' + str(payload['number']))
+        else:
+            self.assertEqual(found_filter_text, filter_text)
+
+        self.orders_page.filter_apply()
+        self.orders_page.close_filter_menu()
+        results = self.order_page.result_table()
+        self.assertGreaterEqual(len(results), 1)
+        for i in range(len(results) - 1):
+            suborders = self.orders_page.get_child_table_data(index=i)
+            key_found = False
+            for suborder in suborders:
+                if payload['name'] == suborder['Test Units']:
+                    key_found = True
+                    break
+            self.assertTrue(key_found)
+            # close child table
+            self.orders_page.close_child_table(source=results[i])
+
 
 


### PR DESCRIPTION
https://modeso.atlassian.net/browse/LIMS-7444 is duplicated with :
https://github.com/modeso-open-source/1lims-automation/blob/c36ce61374cfc53240df06d8255ca76714f30b8f/ui_testing/testcases/basic_tests/test006_orders.py#L2623
So, I only added it's label to implemented test case 

and Implemented : https://modeso.atlassian.net/browse/LIMS-7411

```
➜  1lims-automation git:(LIMS-7411) export PYTHONPATH='./'
➜  1lims-automation git:(LIMS-7411) ✗ nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test006_orders.py:OrdersTestCases.test100_test_unit_name_allow_user_to_filter_with_selected_two_options_order_1_Unit
2020-09-11 06:28:05.024 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-11 06:28:05.024 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-11 06:28:05.482 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : FVL1FePzorVvHtobRaV_OuCCxji2UcJcCUrjbNS-1eA .....
Orders: Filter test unit Approach: Allow the search criteria in [with search_view_option1='Unit', search_view_option2='No'] ...         
2020-09-11 06:28:23.642 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test100_test_unit_name_allow_user_to_filter_with_selected_two_options_order_1_Unit
2020-09-11 06:28:28.720 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:582 - wait until page is loaded
2020-09-11 06:28:28.766 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:29.499 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:30.195 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:428 - set test unit configuration
2020-09-11 06:28:30.645 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-11 06:28:30.646 | INFO     | api_testing.apis.orders_api:set_configuration:432 - set order configuration
2020-09-11 06:28:31.067 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-11 06:28:31.068 | INFO     | ui_testing.pages.testunits_page:get_test_units_page:11 -  + Get test units page.
2020-09-11 06:28:34.357 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:582 - wait until page is loaded
2020-09-11 06:28:34.397 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:35.114 | INFO     | ui_testing.pages.testunits_page:open_configurations:94 - open testunits configurations
2020-09-11 06:28:35.381 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:36.635 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-11 06:28:38.323 | INFO     | ui_testing.pages.testunits_page:open_testunit_name_configurations_options:102 - open testunits name configurations options
2020-09-11 06:28:38.323 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:39.373 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:40.567 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:41.360 | INFO     | ui_testing.pages.testunits_page:clear_all_selected_view_and_search_options:110 - clear selected view and search options of testunits name
2020-09-11 06:28:41.517 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:28:57.567 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-11 06:28:59.231 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-11 06:29:00.896 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_test_unit_name_allow_user_to_filter_with_selected_two_options_order:3239 - Create new quantitative test unit with unit and quantification
2020-09-11 06:29:00.897 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-11 06:29:01.344 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:01.346 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/1400
2020-09-11 06:29:01.480 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:01.480 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_test_unit_name_allow_user_to_filter_with_selected_two_options_order:3246 - create new order created test unit number
2020-09-11 06:29:01.481 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders/auto/generatedOrderNumber/?yearOption=1
2020-09-11 06:29:01.599 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:01.600 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-11 06:29:04.785 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:04.786 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/materialTypes
2020-09-11 06:29:04.877 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:04.877 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans/get/85410
2020-09-11 06:29:04.995 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:04.996 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/contacts
2020-09-11 06:29:05.128 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:05.128 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-11 06:29:05.496 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-11 06:29:08.613 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:582 - wait until page is loaded
2020-09-11 06:29:08.644 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:29:09.366 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:29:10.079 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:29:11.124 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:29:22.462 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:582 - wait until page is loaded
2020-09-11 06:29:22.628 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-11 06:29:23.862 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-11 06:29:29.148 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-11 06:29:31.301 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 85.353s

OK
```