### PR TITLE
LIMS-6814 & LIMS-6821:Orders: Popup should appear when editing then clicking on overview without saving <All data will be lost>, No popup should appear when clicking on overview without changing anything

### DIFF
--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -5,7 +5,7 @@ EXECUTION_FILES=(
      ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test100'
+ TEST_REG='test103'
 
 
  NODE_TOTAL=$1;

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -5,7 +5,7 @@ EXECUTION_FILES=(
      ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test101'
+ TEST_REG='test100'
 
 
  NODE_TOTAL=$1;

--- a/ui_testing/pages/base_pages.py
+++ b/ui_testing/pages/base_pages.py
@@ -86,6 +86,9 @@ class BasePages:
                 self.base_selenium.click(element='general:confirm_cancel')
         self.sleep_small()
 
+    def get_confirmation_pop_up_text(self):
+        return self.base_selenium.get_text(element='general:confirmation_pop_up')
+
     def open_filter_menu(self):
         self.info('open Filter')
         filter = self.base_selenium.find_element_in_element(source_element='general:menu_filter_view',

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3558,8 +3558,7 @@ class OrdersTestCases(BaseTest):
             self.order_page.set_contact(remove_old=True)
         self.order_page.click_overview()
         if edit_case == 'update_a_field':
-            self.assertIn('All data will be lost',
-                          self.base_selenium.find_element(element='general:confirmation_pop_up').text)
+            self.assertIn('All data will be lost', self.order_page.get_confirmation_pop_up_text())
             self.assertTrue(self.order_page.confirm_popup(check_only=True))
         else:
             self.assertFalse(self.order_page.confirm_popup(check_only=True))

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3539,3 +3539,29 @@ class OrdersTestCases(BaseTest):
             else:
                 self.assertCountEqual(test_units_names, third_suborder_test_units)
 
+    @parameterized.expand(['update_a_field', 'no_updates'])
+    def test100_edit_order_page_then_overview(self, edit_case):
+        """
+        Orders: Popup should appear when editing then clicking on overview without saving <All data will be lost>
+        LIMS-6814
+
+        Orders: No popup should appear when clicking on overview without changing anything
+        LIMS-6821
+        """
+        random_order = random.choice(self.orders_api.get_all_orders_json())
+        self.info('edit order with No {}'.format(random_order['orderNo']))
+        self.order_page.filter_by_order_no(random_order['orderNo'])
+        row = self.orders_page.result_table()[0]
+        self.order_page.open_edit_page(row=row)
+        if edit_case == 'update_a_field':
+            self.info('update the contact field')
+            self.order_page.set_contact(remove_old=True)
+        self.order_page.click_overview()
+        if edit_case == 'update_a_field':
+            self.assertIn('All data will be lost',
+                          self.base_selenium.find_element(element='general:confirmation_pop_up').text)
+            self.assertTrue(self.order_page.confirm_popup(check_only=True))
+        else:
+            self.assertFalse(self.order_page.confirm_popup(check_only=True))
+            self.info('asserting redirection to active table')
+            self.assertEqual(self.order_page.orders_url, self.base_selenium.get_url())


### PR DESCRIPTION
```
2020-09-22 00:04:10.824 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-22 00:04:10.827 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-22 00:04:11.715 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : 6aeOuqYxBjIH_6FeWhQPinaW5at6acMj-J3vSmj_TJE .....

DevTools listening on ws://127.0.0.1:51723/devtools/browser/b5208449-353f-4c92-839c-d1a4d9ae7051
test100_edit_order_page_then_overview_0_update_a_field (ui_testing.testcases.basic_tests.test006_orders.OrdersTestCases) ...
2020-09-22 00:04:34.596 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test100_edit_order_page_then_overview_0_update_a_field
2020-09-22 00:04:38.074 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:04:38.626 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:39.359 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:40.068 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 00:04:40.826 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 00:04:40.832 | INFO     | api_testing.apis.orders_api:set_configuration:502 - set order configuration
2020-09-22 00:04:41.465 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 00:04:41.468 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 00:04:42.304 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 00:04:42.307 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_edit_order_page_then_overview:3545 - edit order with No 33-2020
2020-09-22 00:04:42.500 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 33-2020
2020-09-22 00:04:43.193 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:04:43.452 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:44.187 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:44.908 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:45.862 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:04:46.484 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:47.434 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_edit_order_page_then_overview:3551 - update the contact field
2020-09-22 00:04:52.799 | INFO     | ui_testing.pages.base_pages:click_overview:467 - click on Overview
2020-09-22 00:04:52.905 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:53.961 | INFO     | ui_testing.pages.base_pages:confirm_popup:79 - confirming the popup
2020-09-22 00:04:53.986 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 00:04:55.907 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok
test100_edit_order_page_then_overview_1_no_updates (ui_testing.testcases.basic_tests.test006_orders.OrdersTestCases) ...
2020-09-22 00:04:55.910 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test100_edit_order_page_then_overview_1_no_updates
2020-09-22 00:04:57.842 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:04:57.866 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:58.660 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:04:59.477 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 00:05:00.208 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 00:05:00.215 | INFO     | api_testing.apis.orders_api:set_configuration:502 - set order configuration
2020-09-22 00:05:00.833 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 00:05:00.838 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 00:05:01.455 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 00:05:01.460 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_edit_order_page_then_overview:3545 - edit order with No 9-2020
2020-09-22 00:05:01.639 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 9-2020
2020-09-22 00:05:02.534 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:05:02.843 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:05:03.654 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:05:04.535 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:05:05.557 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 00:05:06.114 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:05:07.262 | INFO     | ui_testing.pages.base_pages:click_overview:467 - click on Overview
2020-09-22 00:05:07.402 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 00:05:08.880 | INFO     | ui_testing.pages.base_pages:confirm_popup:79 - confirming the popup
2020-09-22 00:05:08.891 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-22 00:05:10.470 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test100_edit_order_page_then_overview:3562 - asserting redirection to active table
2020-09-22 00:05:10.479 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 00:05:12.129 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 2 tests in 62.143s

OK

```