### PR TITLE
LIMS-5220: Allow user to add any number of the suborders records not only 5 suborders

### DIFF
--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -4,7 +4,7 @@ EXECUTION_FILES=(
   ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test102'
+ TEST_REG='test106'
 
 
  NODE_TOTAL=$1;

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3575,7 +3575,7 @@ class OrdersTestCases(BaseTest):
             test_units = [item['Test Unit'] for item in child_data]
             self.assertCountEqual(test_units, test_units_names[i * 2:(i * 2) + 2])
 
-    def test106_choose_test_plans_without_test_units(self):
+    def test106_multiple_suborders(self):
         """
         Orders: Table with add: Allow user to add any number of the suborders records not only 5 suborders
 
@@ -3588,11 +3588,15 @@ class OrdersTestCases(BaseTest):
         self.orders_page.get_order_edit_page_by_id(response['order']['mainOrderId'])
         suborder_table = self.base_selenium.get_table_rows(element='order:suborder_table')
         self.assertEqual(len(suborder_table), 10)
+        self.order_page.create_new_suborder(material_type=testPlan['materialType'][0]['text'],
+                                            article_name=testPlan['selectedArticles'][0]['text'],
+                                            test_plans=[testPlan['testPlan']['text']], test_units=[])
+        self.order_page.sleep_tiny()
+        self.order_page.save(save_btn='order:save_btn')
         self.info('duplicate 5 suborders')
         self.order_page.duplicate_from_table_view(number_of_duplicates=5)
-        self.order_page.save(save_btn='order:save_btn')
-        self.base_selenium.refresh()
+        self.order_page.save_and_wait(save_btn='order:save_btn')
         table_after2 = self.base_selenium.get_table_rows(element='order:suborder_table')
-        self.assertEqual(len(table_after2), 15)
+        self.assertEqual(len(table_after2), 16)
         self.order_page.navigate_to_analysis_tab()
-        self.assertEqual(SingleAnalysisPage().get_analysis_count(), 15)
+        self.assertEqual(SingleAnalysisPage().get_analysis_count(), 16)

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3575,3 +3575,24 @@ class OrdersTestCases(BaseTest):
             test_units = [item['Test Unit'] for item in child_data]
             self.assertCountEqual(test_units, test_units_names[i * 2:(i * 2) + 2])
 
+    def test106_choose_test_plans_without_test_units(self):
+        """
+        Orders: Table with add: Allow user to add any number of the suborders records not only 5 suborders
+
+        LIMS-5220
+        """
+        response, payload = self.orders_api.create_order_with_multiple_suborders(no_suborders=10)
+        self.assertEqual(response['status'], 1)
+        testPlan = TestPlanAPI().create_completed_testplan_random_data()
+        self.assertTrue(testPlan)
+        self.orders_page.get_order_edit_page_by_id(response['order']['mainOrderId'])
+        suborder_table = self.base_selenium.get_table_rows(element='order:suborder_table')
+        self.assertEqual(len(suborder_table), 10)
+        self.info('duplicate 5 suborders')
+        self.order_page.duplicate_from_table_view(number_of_duplicates=5)
+        self.order_page.save(save_btn='order:save_btn')
+        self.base_selenium.refresh()
+        table_after2 = self.base_selenium.get_table_rows(element='order:suborder_table')
+        self.assertEqual(len(table_after2), 15)
+        self.order_page.navigate_to_analysis_tab()
+        self.assertEqual(SingleAnalysisPage().get_analysis_count(), 15)


### PR DESCRIPTION
https://modeso.atlassian.net/browse/LIMS-5220
Omina implemented it using GUI, so I updated it in this PR to be in API.
```
➜  1lims-automation git:(LIMS-5220-gh) ✗ nosetests -vs --nologcapture --tc-file=config.ini ui_testing/testcases/basic_tests/test006_orders.py:OrdersTestCases.test106_multiple_suborders
2020-09-22 16:47:00.231 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-22 16:47:00.232 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-22 16:47:00.804 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : 0BripEijO-GQDJtzumu_E0X6dZLYaTTj4PY9QvZPq6s .....
Orders: Table with add: Allow user to add any number of the suborders records not only 5 suborders ...  
2020-09-22 16:47:20.406 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test106_multiple_suborders
2020-09-22 16:47:24.503 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 16:47:24.550 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:25.242 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:25.968 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 16:47:26.427 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 16:47:26.428 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-22 16:47:26.927 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 16:47:26.927 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders/auto/generatedOrderNumber/?yearOption=1
2020-09-22 16:47:27.271 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:27.271 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/contacts
2020-09-22 16:47:27.420 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:27.420 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/articles
2020-09-22 16:47:27.738 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:27.738 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/materialTypes
2020-09-22 16:47:27.828 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:27.829 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-22 16:47:27.973 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:27.974 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/213
2020-09-22 16:47:28.078 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:28.079 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-22 16:47:28.248 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:28.249 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 16:47:28.515 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:28.516 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/articles
2020-09-22 16:47:28.746 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:28.746 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/materialTypes
2020-09-22 16:47:28.836 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:28.837 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-22 16:47:29.034 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:29.034 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/214
2020-09-22 16:47:29.146 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:29.146 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-22 16:47:29.290 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 16:47:31.644 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 16:47:32.535 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:33.264 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:34.059 | INFO     | ui_testing.pages.order_page:create_new_suborder:383 - Add new suborder.
2020-09-22 16:47:34.816 | INFO     | ui_testing.pages.order_page:create_new_suborder:389 - Set material type : R&D
2020-09-22 16:47:42.651 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:44.001 | INFO     | ui_testing.pages.order_page:create_new_suborder:392 - Set article name : a6fdd27b9b
2020-09-22 16:47:44.002 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:54.711 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:47:55.652 | INFO     | ui_testing.pages.order_page:create_new_suborder:400 - Set test plan : ['a650239203']
2020-09-22 16:48:03.504 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:04.259 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:05.098 | INFO     | ui_testing.pages.order_page:get_suborder_data:434 - getting main order data
2020-09-22 16:48:05.258 | INFO     | ui_testing.pages.order_page:get_suborder_data:441 - getting suborders data
2020-09-22 16:48:12.424 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:13.171 | INFO     | ui_testing.pages.base_pages:save:55 - save the changes
2020-09-22 16:48:13.171 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:14.208 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:15.805 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test106_multiple_suborders:3596 - duplicate 5 suborders
2020-09-22 16:48:18.914 | INFO     | ui_testing.pages.base_pages:save:55 - save the changes
2020-09-22 16:48:18.915 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:19.886 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:21.829 | INFO     | ui_testing.pages.base_pages:save_and_wait:64 - Refresh to make sure that data are saved correctly
2020-09-22 16:48:26.854 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 16:48:26.897 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:28.097 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 16:48:28.650 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 16:48:29.427 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 16:48:31.554 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 90.480s

OK


```