### PR TITLE
LIMS-4110: Orders: Search/filter Approach: User can search/filter by all the new number format ( without year, number before year, number after year

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,31 +21,4 @@
        - name: parallel execution for each module
          run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
 
-#  test_pull_request_in_series:
-#    runs-on: ubuntu-20.04
-#    needs: test_pull_request_in_parallel
-#    if: always()
-#    strategy:
-#      fail-fast: false
-#
-#    steps:
-#      - uses: actions/checkout@master
-#
-#      - name: pull docker image
-#        run:  docker pull 0xislamtaha/seleniumchromenose:83
-#
-#      - name: sequal execution for series
-#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
-#
-#  merge_launches:
-#    runs-on: ubuntu-20.04
-#    needs: [test_pull_request_in_parallel, test_pull_request_in_series]
-#    if: always()
-#    strategy:
-#      fail-fast: false
-#
-#    steps:
-#      - uses: actions/checkout@master
-#
-#      - name: merge launches
-#        run:  python3 fixReport.py ${{ secrets.UUID }} ${{ github.head_ref }}-${{ github.run_id }}-${{ github.run_number }}
+

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -1,47 +1,47 @@
-# #!/bin/bash
+ #!/bin/bash
 
-# EXECUTION_FILES=(
-#     ui_testing/testcases/basic_tests/test006_orders.py
-#   )
+ EXECUTION_FILES=(
+     ui_testing/testcases/basic_tests/test006_orders.py
+   )
 
-# TEST_REG='test106'
+ TEST_REG='test103'
 
 
-#  NODE_TOTAL=$1;
-#  NODE_INDEX=$2;
-#  RUN_REF=$3;
-#  RUN_ID=$4;
-#  RUN_NUMBER=$5;
-#  WORK_DIR=$6;
-#  ATTR=$7;
-#  UUID=$8;
+  NODE_TOTAL=$1;
+  NODE_INDEX=$2;
+  RUN_REF=$3;
+  RUN_ID=$4;
+  RUN_NUMBER=$5;
+  WORK_DIR=$6;
+  ATTR=$7;
+  UUID=$8;
 
-#  echo 'NODE_TOTAL: ' $NODE_TOTAL;
-#  echo 'NODE_INDEX: ' $NODE_INDEX;
-#  echo 'TEST_REG: ' $TEST_REG;
-#  echo 'RUN_REF: ' $RUN_REF;
-#  echo 'RUN_ID: ' $RUN_ID;
-#  echo 'RUN_NUMBER: ' $RUN_NUMBER;
-#  echo 'WORK_DIR: ' $WORK_DIR;
-#  EXECUTION_RESULT=()
+  echo 'NODE_TOTAL: ' $NODE_TOTAL;
+  echo 'NODE_INDEX: ' $NODE_INDEX;
+  echo 'TEST_REG: ' $TEST_REG;
+  echo 'RUN_REF: ' $RUN_REF;
+  echo 'RUN_ID: ' $RUN_ID;
+  echo 'RUN_NUMBER: ' $RUN_NUMBER;
+  echo 'WORK_DIR: ' $WORK_DIR;
+  EXECUTION_RESULT=()
 
-#  for TEST_FILE in "${EXECUTION_FILES[@]}"
-#   do
-#     echo 'TEST_FILE: ' $TEST_FILE;
-#     if [[ $ATTR = "not series" ]]
-#      then
-#        docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=$NODE_TOTAL NODE_INDEX=$NODE_INDEX nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
-#        EXECUTION_RESULT+=($?)
-#      else
-#        docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
-#        EXECUTION_RESULT+=($?)
-#     fi
-#   done
+  for TEST_FILE in "${EXECUTION_FILES[@]}"
+   do
+     echo 'TEST_FILE: ' $TEST_FILE;
+     if [[ $ATTR = "not series" ]]
+      then
+        docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "NODE_TOTAL=$NODE_TOTAL NODE_INDEX=$NODE_INDEX nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 --with-parallel -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
+        EXECUTION_RESULT+=($?)
+      else
+        docker container run -t --shm-size=2g -v $WORK_DIR:/1lims-automation -e "PYTHONPATH='$PYTHONPATH:/1lims-automation" -w /1lims-automation 0xislamtaha/seleniumchromenose:83 bash -c "nosetests -vs --nologcapture --with-reportportal --rp-config-file rp.ini --rp-uuid $UUID --rp-launch-description=$RUN_REF-$RUN_ID-$RUN_NUMBER --rp-logging-level=WARNING --tc-file=config.ini --tc=browser.headless:True --with-flaky --force-flaky --max-runs=3 --min-passes=1 -A '$ATTR' -m '$TEST_REG' $TEST_FILE"
+        EXECUTION_RESULT+=($?)
+     fi
+   done
 
-#  for exit_code in "${EXECUTION_RESULT[@]}"
-#  do
-#    if [[ $exit_code = 1 ]]
-#    then
-#      exit 1;
-#    fi
-#  done
+  for exit_code in "${EXECUTION_RESULT[@]}"
+  do
+    if [[ $exit_code = 1 ]]
+    then
+      exit 1;
+    fi
+  done

--- a/ui_testing/elements.py
+++ b/ui_testing/elements.py
@@ -619,6 +619,9 @@ elements = {
         'analysis_tab': {
             'method': 'xpath',
             'value': "//label[@class='btn tab']"},
+        'order_tab': {
+            'method': 'xpath',
+            'value': "//label[@class='btn tab']"},
         'mainorder_duplicate': {'method': 'id',
                                 'value': 'main_table_duplicate'},
         'mainorder-archive' : {'method' : 'id',

--- a/ui_testing/pages/orders_page.py
+++ b/ui_testing/pages/orders_page.py
@@ -364,3 +364,7 @@ class Orders(BasePages):
         list = items[0].text.split('\n')
         return list
 
+    def navigate_to_order_active_table(self):
+        self.base_selenium.click(element='orders:order_tab')
+        self.sleep_medium()
+

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -181,7 +181,7 @@ class OrdersTestCases(BaseTest):
         self.orders_page.get_archived_items()
         self.orders_page.filter_by_order_no(order_no)
         if order_type == 'suborder':
-            random_index = randint(0, len(suborders)-1)
+            random_index = randint(0, len(suborders) - 1)
             suborders_data = self.order_page.get_child_table_data()
             self.info("Restore suborder with analysis No {}".format(suborders_data[random_index]['Analysis No.']))
             self.order_page.restore_table_suborder(index=random_index)
@@ -1465,7 +1465,7 @@ class OrdersTestCases(BaseTest):
         self.order_page.get_orders_page()
         self.order_page.filter_by_order_no(random_order['orderNo'])
         suborder_data = self.order_page.get_child_table_data()
-        self.assertTrue(len(suborder_data), len(suborders)+1)
+        self.assertTrue(len(suborder_data), len(suborders) + 1)
         self.orders_page.navigate_to_analysis_active_table()
         self.analyses_page.filter_by_analysis_number(suborder_data[0]['Analysis No.'])
         analysis_result = self.analyses_page.get_the_latest_row_data()['Analysis No.'].replace("'", "")
@@ -2540,7 +2540,7 @@ class OrdersTestCases(BaseTest):
         self.info('asserting the order with order number {} is created'.format(order_no))
         self.assertIn(order_no_with_year, results[0].text.replace("'", ""))
 
-    #@skip("https://modeso.atlassian.net/browse/LIMSA-299")
+    # @skip("https://modeso.atlassian.net/browse/LIMSA-299")
     def test074_create_existing_order_change_contact(self):
         """
          Create existing order then change the contact for this existing one,
@@ -3305,9 +3305,9 @@ class OrdersTestCases(BaseTest):
             if result['test_plan'] == testPlan['testPlan']['text']:
                 for testunit in testunit_names:
                     self.assertIn(testunit, result['test_units'])
-                  
-    @parameterized.expand(['Name','No','Name:No'])
-    def test095_change_contact_config(self,search_by):
+
+    @parameterized.expand(['Name', 'No', 'Name:No'])
+    def test095_change_contact_config(self, search_by):
         '''
          Orders: Contact configuration approach: In case the user
          configures the contact field to display name & number this action
@@ -3318,18 +3318,18 @@ class OrdersTestCases(BaseTest):
         '''
         self.contacts_page = Contacts()
         self.info('get random contact')
-        contacts_response,_ = ContactsAPI().get_all_contacts(limit=10)
+        contacts_response, _ = ContactsAPI().get_all_contacts(limit=10)
         self.assertEqual(contacts_response['status'], 1)
         payload = random.choice(contacts_response['contacts'])
         self.orders_page.open_order_config()
         self.info('change contact view by options')
         self.contacts_page.open_contact_configurations_options()
-        if  search_by == 'Name':
+        if search_by == 'Name':
             search_text = payload['name']
             result = payload['name']
             search_by = [search_by]
-        elif search_by== 'No':
-            search_text = 'No: '+ str(payload['companyNo'])
+        elif search_by == 'No':
+            search_text = 'No: ' + str(payload['companyNo'])
             result = str(payload['companyNo'])
             search_by = [search_by]
         elif search_by == 'Name:No':
@@ -3344,7 +3344,7 @@ class OrdersTestCases(BaseTest):
         rows = self.orders_page.result_table()
         order_data = self.base_selenium.get_row_cells_dict_related_to_header(row=rows[0])
         self.info('assert contact appear in format {}'.format(search_by))
-        self.assertEqual(order_data['Contact Name'],search_text)
+        self.assertEqual(order_data['Contact Name'], search_text)
 
     def test096_check_list_menu(self):
         """
@@ -3632,3 +3632,33 @@ class OrdersTestCases(BaseTest):
             test_units_name = test_units[0]['Test Unit Name'].split(' ')[0]
             self.assertEqual(test_units_name, test_units_list[i])
 
+    @parameterized.expand(['without year', 'number before year', 'number after year'])
+    def test103_search_by_all_formats(self,format):
+        '''
+        Orders: Search/filter Approach: User can search/filter by all the new number format ( without year, number before year, number after year
+        LIMS-4110
+        :return:
+        '''
+        random_order = random.choice(self.orders_api.get_all_orders_json())
+        if format == 'without year':
+            order_no = random_order['orderNo'].split('-')[0]
+        elif format == 'number before year':
+            order_no = random_order['orderNo']
+        elif format == 'number after year':
+            order_no = random_order['orderNo'].split('-')[1]+'-'+random_order['orderNo'].split('-')[0]
+        self.info('can filter in order active table with order no in format .{}'.format(format))
+        self.orders_page.filter_by_order_no(order_no)
+        rows = self.orders_page.result_table()
+        self.assertGreater(len(rows)-1,0)
+        self.base_selenium.refresh()
+        self.info('can search in order active table with order no in format .{}'.format(format))
+        self.orders_page.search(order_no)
+        self.assertGreater(len(rows) - 1, 0)
+        self.orders_page.navigate_to_analysis_active_table()
+        self.info('can filter in analysis active table with order no in format .{}'.format(format))
+        self.analyses_page.filter_by_order_no(order_no)
+        self.base_selenium.refresh()
+        self.info('can search in analysis active table with order no in format .{}'.format(format))
+        self.orders_page.search(order_no)
+        self.assertGreater(len(rows) - 1, 0)
+        self.orders_page.navigate_to_order_active_table()#in order to open on order tab in the second run


### PR DESCRIPTION
```
C:\Users\omnia\Documents\1lims-app\1lims-automation>nosetests -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py -m test103 --tc-file=config.ini
c:\users\omnia\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named 'fcntl'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-22 22:41:43.025 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-22 22:41:43.026 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-22 22:41:43.733 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : z1PVeLa_18c6McCIX0MwOgMWYjwVunViwyeapnzFJUI .....

DevTools listening on ws://127.0.0.1:61127/devtools/browser/3e05f06a-5328-43b4-8fac-c9b8032f51f8
Orders: Search/filter Approach: User can search/filter by all the new number format ( without year, number before year, number after year [with format='without year'] ...
2020-09-22 22:42:21.547 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test103_search_by_all_formats_0_without_year
2020-09-22 22:42:26.056 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:42:26.085 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:42:26.841 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:42:27.575 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 22:42:28.228 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:42:28.236 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-22 22:42:28.814 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:42:28.823 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 22:42:30.188 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 22:42:30.193 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3649 - can filter in order active table with order no in format .without year
2020-09-22 22:42:30.390 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 111
2020-09-22 22:42:31.343 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:42:32.286 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:42:32.990 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:42:33.684 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:42:43.650 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3654 - can search in order active table with order no in format .without year
2020-09-22 22:42:54.453 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-22 22:42:57.576 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3658 - can filter in analysis active table with order no in format .without year
2020-09-22 22:42:57.578 | INFO     | ui_testing.pages.analyses_page:filter_by_order_no:22 - Filter by order number : 111
2020-09-22 22:42:57.579 | INFO     | ui_testing.pages.base_pages:open_filter_menu:90 - open Filter
2020-09-22 22:43:07.741 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:43:07.936 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:15.138 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3661 - can search in analysis active table with order no in format .without year
2020-09-22 22:43:25.812 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-22 22:43:29.794 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 22:43:31.493 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok
Orders: Search/filter Approach: User can search/filter by all the new number format ( without year, number before year, number after year [with format='number before year'] ...
2020-09-22 22:43:31.496 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test103_search_by_all_formats_1_number_before_year
2020-09-22 22:43:32.963 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:43:33.494 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:34.291 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:35.084 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 22:43:35.876 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:43:35.878 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-22 22:43:36.480 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:43:36.483 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 22:43:37.612 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 22:43:37.621 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3649 - can filter in order active table with order no in format .number before year
2020-09-22 22:43:37.797 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 48-2020
2020-09-22 22:43:38.662 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:43:38.931 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:39.701 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:40.592 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:43:47.875 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3654 - can search in order active table with order no in format .number before year
2020-09-22 22:43:58.559 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-22 22:44:01.033 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3658 - can filter in analysis active table with order no in format .number before year
2020-09-22 22:44:01.036 | INFO     | ui_testing.pages.analyses_page:filter_by_order_no:22 - Filter by order number : 48-2020
2020-09-22 22:44:01.037 | INFO     | ui_testing.pages.base_pages:open_filter_menu:90 - open Filter
2020-09-22 22:44:09.625 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:44:09.799 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:17.174 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3661 - can search in analysis active table with order no in format .number before year
2020-09-22 22:44:27.843 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-22 22:44:31.072 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 22:44:32.131 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok
Orders: Search/filter Approach: User can search/filter by all the new number format ( without year, number before year, number after year [with format='number after year'] ...
2020-09-22 22:44:32.134 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test103_search_by_all_formats_2_number_after_year
2020-09-22 22:44:33.201 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:44:33.637 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:34.430 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:35.252 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-22 22:44:36.069 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:44:36.077 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-22 22:44:37.026 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-22 22:44:37.040 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-22 22:44:37.916 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-22 22:44:37.924 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3649 - can filter in order active table with order no in format .number after year
2020-09-22 22:44:38.086 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 2020-16
2020-09-22 22:44:38.942 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:44:39.202 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:40.023 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:40.896 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:44:48.035 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3654 - can search in order active table with order no in format .number after year
2020-09-22 22:44:58.689 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-22 22:45:01.247 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3658 - can filter in analysis active table with order no in format .number after year
2020-09-22 22:45:01.250 | INFO     | ui_testing.pages.analyses_page:filter_by_order_no:22 - Filter by order number : 2020-16
2020-09-22 22:45:01.251 | INFO     | ui_testing.pages.base_pages:open_filter_menu:90 - open Filter
2020-09-22 22:45:11.233 | INFO     | ui_testing.pages.base_selenium:select_item_from_drop_down:499 -  There is no 2020-16 option in the drop-down
2020-09-22 22:45:11.468 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:603 - wait until page is loaded
2020-09-22 22:45:12.336 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-22 22:45:19.621 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test103_search_by_all_formats:3661 - can search in analysis active table with order no in format .number after year
2020-09-22 22:45:30.372 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-22 22:45:33.599 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-22 22:45:34.897 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 3 tests in 232.867s

OK

```