### PR TITLE
LIMS-2622: Orders: Analysis number Approach: Make sure that the analys…

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,38 +5,38 @@
      branches: [ master ]
 
  jobs:
-#   test_pull_request_in_parallel:
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         test_cases: [0]
+   test_pull_request_in_parallel:
+     runs-on: ubuntu-20.04
+     strategy:
+       fail-fast: false
+       matrix:
+         test_cases: [0]
+
+     steps:
+       - uses: actions/checkout@master
+
+       - name: pull docker image
+         run:  docker pull 0xislamtaha/seleniumchromenose:83
+
+       - name: parallel execution for each module
+         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
 #
-#     steps:
-#       - uses: actions/checkout@master
+#  test_pull_request_in_series:
+#    runs-on: ubuntu-20.04
+##    needs: test_pull_request_in_parallel
+#    if: always()
+#    strategy:
+#      fail-fast: false
 #
-#       - name: pull docker image
-#         run:  docker pull 0xislamtaha/seleniumchromenose:83
+#    steps:
+#      - uses: actions/checkout@master
 #
-#       - name: parallel execution for each module
-#         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
-
-  test_pull_request_in_series:
-    runs-on: ubuntu-20.04
-#    needs: test_pull_request_in_parallel
-    if: always()
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@master
-
-      - name: pull docker image
-        run:  docker pull 0xislamtaha/seleniumchromenose:83
-
-      - name: sequal execution for series
-        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
-
+#      - name: pull docker image
+#        run:  docker pull 0xislamtaha/seleniumchromenose:83
+#
+#      - name: sequal execution for series
+#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
+#
 #  merge_launches:
 #    runs-on: ubuntu-20.04
 #    needs: [test_pull_request_in_parallel, test_pull_request_in_series]

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 EXECUTION_FILES=(
-     ui_testing/testcases/extended_tests/test001_order.py
+     ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test004'
+ TEST_REG='test107'
 
 
  NODE_TOTAL=$1;

--- a/ui_testing/elements.py
+++ b/ui_testing/elements.py
@@ -557,6 +557,9 @@ elements = {
                                'value': '//span[contains(text(),"Analysis")]'},
         'order_analysis_tab': {'method': 'xpath',
                                'value': '//span[contains(text(),"Orders")]'},
+        'highlighted_element' :
+            {'method' : 'xpath',
+             'value' : '//*[@id="DataTables_Table_0"]/tbody/tr[1]/td[13]/app-column-display/span/span/mark'},
         'new_order': {'method': 'id',
                       'value': 'add-btn'},
         'right_menu': {'method': 'xpath',

--- a/ui_testing/pages/base_pages.py
+++ b/ui_testing/pages/base_pages.py
@@ -434,12 +434,15 @@ class BasePages:
         if apply_button:
             apply_button.click()
 
-    def set_all_configure_table_columns_to_specific_value(self, value=True, always_hidden_columns=['']):
+    def set_all_configure_table_columns_to_specific_value(self, value=True, always_hidden_columns=[''], child=False,
+                                                          source_element_to_find='general:configure_table_items') :
         self.open_configure_table()
+        if child :
+            self.base_selenium.click(element='general:configure_child_table')
         total_columns = self.base_selenium.find_elements_in_element(
-            source_element='general:configure_table_items',
+            source_element=source_element_to_find,
             destination_element='general:li')
-        for column in total_columns:
+        for column in total_columns :
             self.change_column_view(column=column, value=value, always_hidden_columns=always_hidden_columns)
         self.press_apply_in_configure_table()
 

--- a/ui_testing/pages/base_pages.py
+++ b/ui_testing/pages/base_pages.py
@@ -435,14 +435,14 @@ class BasePages:
             apply_button.click()
 
     def set_all_configure_table_columns_to_specific_value(self, value=True, always_hidden_columns=[''], child=False,
-                                                          source_element_to_find='general:configure_table_items') :
+                                                          element='general:configure_table_items'):
         self.open_configure_table()
-        if child :
+        if child:
             self.base_selenium.click(element='general:configure_child_table')
         total_columns = self.base_selenium.find_elements_in_element(
-            source_element=source_element_to_find,
+            source_element=element,
             destination_element='general:li')
-        for column in total_columns :
+        for column in total_columns:
             self.change_column_view(column=column, value=value, always_hidden_columns=always_hidden_columns)
         self.press_apply_in_configure_table()
 

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3666,27 +3666,14 @@ class OrdersTestCases(BaseTest):
           should display in the order child table
           LIMS-2622
         """
-        self.base_pages = BasePages()
-        self.base_pages.set_all_configure_table_columns_to_specific_value(child=True,
-                                                                          source_element_to_find='general:configure_child_table_items')
-        self.orders_page.open_child_table(self.orders_page.result_table()[0])
-        self.info("Check if Analysis No. heading is displayed in Child Table")
-        headers = self.base_selenium.get_table_head_elements(element='general:table_child')
-        Child_table_headings = [i.text for i in headers]
-        self.assertIn('Analysis No.', Child_table_headings)
-
+        self.orders_page.set_all_configure_table_columns_to_specific_value(
+            child=True, element='general:configure_child_table_items')
+        first_child_data = self.orders_page.get_child_table_data()
+        self.info("Check if Analysis No. displayed in Child Table headers")
+        self.assertIn('Analysis No.', first_child_data[0].keys())
         self.info("Searching by the analysis number displayed in child table")
-        self.order_page.get_orders_page()
-        random_row = self.orders_page.get_random_table_row(table_element='general:table')
-        self.base_selenium.get_row_cells_dict_related_to_header(random_row)
-        self.orders_page.open_child_table(source=random_row)
-        child_table_data = self.order_page.get_table_data()
-        self.orders_page.filter_by_analysis_number(filter_text=child_table_data[0]['Analysis No.'])
-        child_data_after_filter = self.order_page.get_child_table_data()
-        self.assertEqual(child_table_data[0]['Analysis No.'].replace("'", ""),
-                         child_data_after_filter[0]['Analysis No.'])
-
-        # self.info("Checking the highlighted text background colour")
-        # color = self.base_selenium.element_background_color(element='orders:highlighted_element')
-        # self.info( "Hightlight colour 'yellow' in rgb equals'Hex=ffff00,dec(255,255,0) and in rgba equals 'Hex=ffff0059' ")
-        # self.assertEqual(color, 'rgba(255, 255, 0, 0.35)')
+        self.orders_page.filter_by_analysis_number(filter_text=first_child_data[0]['Analysis No.'])
+        import ipdb;ipdb.set_trace()
+        xpath = "//mark[contains(text(),'{}')]".format(first_child_data[0]['Analysis No.'].replace("'", ""))
+        elem = self.base_selenium.find_element_by_xpath(xpath)
+        self.assertTrue(elem)

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3660,10 +3660,11 @@ class OrdersTestCases(BaseTest):
             self.info('asserting redirection to active table')
             self.assertEqual(self.order_page.orders_url, self.base_selenium.get_url())
 
-    def test107_analysis_number_displayed_in_order_child_table(self) :
+    def test107_analysis_number_displayed_in_order_child_table(self):
         """
           Orders: Analysis number Approach: Make sure that the analysis number
           should display in the order child table
+
           LIMS-2622
         """
         self.orders_page.set_all_configure_table_columns_to_specific_value(
@@ -3673,7 +3674,7 @@ class OrdersTestCases(BaseTest):
         self.assertIn('Analysis No.', first_child_data[0].keys())
         self.info("Searching by the analysis number displayed in child table")
         self.orders_page.filter_by_analysis_number(filter_text=first_child_data[0]['Analysis No.'])
-        import ipdb;ipdb.set_trace()
+        self.info("assert that analysis no is marked")
         xpath = "//mark[contains(text(),'{}')]".format(first_child_data[0]['Analysis No.'].replace("'", ""))
         elem = self.base_selenium.find_element_by_xpath(xpath)
         self.assertTrue(elem)

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -10,6 +10,7 @@ from ui_testing.pages.analysis_page import AllAnalysesPage
 from api_testing.apis.article_api import ArticleAPI
 from api_testing.apis.test_unit_api import TestUnitAPI
 from ui_testing.pages.analysis_page import SingleAnalysisPage
+from ui_testing.pages.base_pages import BasePages
 from api_testing.apis.contacts_api import ContactsAPI
 from api_testing.apis.test_plan_api import TestPlanAPI
 from api_testing.apis.users_api import UsersAPI
@@ -3658,3 +3659,34 @@ class OrdersTestCases(BaseTest):
             self.assertFalse(self.order_page.confirm_popup(check_only=True))
             self.info('asserting redirection to active table')
             self.assertEqual(self.order_page.orders_url, self.base_selenium.get_url())
+
+    def test107_analysis_number_displayed_in_order_child_table(self) :
+        """
+          Orders: Analysis number Approach: Make sure that the analysis number
+          should display in the order child table
+          LIMS-2622
+        """
+        self.base_pages = BasePages()
+        self.base_pages.set_all_configure_table_columns_to_specific_value(child=True,
+                                                                          source_element_to_find='general:configure_child_table_items')
+        self.orders_page.open_child_table(self.orders_page.result_table()[0])
+        self.info("Check if Analysis No. heading is displayed in Child Table")
+        headers = self.base_selenium.get_table_head_elements(element='general:table_child')
+        Child_table_headings = [i.text for i in headers]
+        self.assertIn('Analysis No.', Child_table_headings)
+
+        self.info("Searching by the analysis number displayed in child table")
+        self.order_page.get_orders_page()
+        random_row = self.orders_page.get_random_table_row(table_element='general:table')
+        self.base_selenium.get_row_cells_dict_related_to_header(random_row)
+        self.orders_page.open_child_table(source=random_row)
+        child_table_data = self.order_page.get_table_data()
+        self.orders_page.filter_by_analysis_number(filter_text=child_table_data[0]['Analysis No.'])
+        child_data_after_filter = self.order_page.get_child_table_data()
+        self.assertEqual(child_table_data[0]['Analysis No.'].replace("'", ""),
+                         child_data_after_filter[0]['Analysis No.'])
+
+        # self.info("Checking the highlighted text background colour")
+        # color = self.base_selenium.element_background_color(element='orders:highlighted_element')
+        # self.info( "Hightlight colour 'yellow' in rgb equals'Hex=ffff00,dec(255,255,0) and in rgba equals 'Hex=ffff0059' ")
+        # self.assertEqual(color, 'rgba(255, 255, 0, 0.35)')


### PR DESCRIPTION
```
D:\1lims-automation> nosetests -vs -m test107 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-24 19:36:09.321 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-24 19:36:09.324 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-24 19:36:09.990 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : KQGyOkzw0-vx-OXZU1VgpVQ7dV_7EtWHl29wNAgZQd8 .....

DevTools listening on ws://127.0.0.1:62530/devtools/browser/909d3266-391c-4931-a29b-382af1428106
Orders: Analysis number Approach: Make sure that the analysis number ...
2020-09-24 19:36:39.333 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test107_analysis_number_displayed_in_order_child_table
2020-09-24 19:36:43.861 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:609 - wait until page is loaded
2020-09-24 19:36:43.899 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:36:44.801 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:36:45.828 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-24 19:36:46.430 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-24 19:36:46.433 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-24 19:36:47.015 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-24 19:36:47.026 | INFO     | ui_testing.pages.base_pages:open_configure_table:359 - open configure table
2020-09-24 19:36:47.367 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:36:52.804 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-24 19:36:56.988 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test107_analysis_number_displayed_in_order_child_table:3673 - Check if Analysis No. heading is displayed in Child Table
2020-09-24 19:36:57.490 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test107_analysis_number_displayed_in_order_child_table:3678 - Searching by the analysis number displayed in child table
2020-09-24 19:36:59.609 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:609 - wait until page is loaded
2020-09-24 19:36:59.645 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:37:00.464 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:37:02.788 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-24 19:37:08.393 | INFO     | ui_testing.pages.orders_page:filter_by_analysis_number:164 - Filter by analysis number : 30-2'020
2020-09-24 19:37:09.234 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:609 - wait until page is loaded
2020-09-24 19:37:09.408 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:37:10.319 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-24 19:37:11.597 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-24 19:37:17.035 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-24 19:37:19.080 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 70.546s

OK
```