### PR TITLE
8085

### DIFF
--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -2299,36 +2299,36 @@ class OrdersTestCases(BaseTest):
     #     self.assertEqual([department], suborder_data['suborders'][0]['departments'])
     #
     # @skip("https://modeso.atlassian.net/browse/LIMSA-205")
-    # def test064_download_suborder_sheet_for_single_order(self):
-    #     """
-    #     Export order child table
-    #
-    #     LIMS-8085- single order case
-    #     """
-    #     self.info('select random order')
-    #     random_row = self.orders_page.get_random_table_row(table_element='general:table')
-    #     self.orders_page.click_check_box(source=random_row)
-    #     random_row_data = self.base_selenium.get_row_cells_dict_related_to_header(random_row)
-    #     self.orders_page.open_child_table(source=random_row)
-    #     child_table_data = self.order_page.get_table_data()
-    #     order_data_list = []
-    #     order_dict = {}
-    #     for sub_order in child_table_data:
-    #         order_dict.update(random_row_data)
-    #         order_dict.update(sub_order)
-    #         order_data_list.append(order_dict)
-    #         order_dict = {}
-    #
-    #     formatted_orders = self.order_page.match_format_to_sheet_format(order_data_list)
-    #     self.order_page.download_xslx_sheet()
-    #     for index in range(len(formatted_orders)):
-    #         self.info('Comparing the order no {} '.format(formatted_orders[index][0]))
-    #         values = self.order_page.sheet.iloc[index].values
-    #         fixed_sheet_row_data = self.reformat_data(values)
-    #         self.assertCountEqual(fixed_sheet_row_data, formatted_orders[index],
-    #                               f"{str(fixed_sheet_row_data)} : {str(formatted_orders[index])}")
-    #         for item in formatted_orders[index]:
-    #             self.assertIn(item, fixed_sheet_row_data)
+    def test064_download_suborder_sheet_for_single_order(self):
+        """
+        Export order child table
+
+        LIMS-8085- single order case
+        """
+        self.info('select random order')
+        random_row = self.orders_page.get_random_table_row(table_element='general:table')
+        self.orders_page.click_check_box(source=random_row)
+        random_row_data = self.base_selenium.get_row_cells_dict_related_to_header(random_row)
+        self.orders_page.open_child_table(source=random_row)
+        child_table_data = self.order_page.get_table_data()
+        order_data_list = []
+        order_dict = {}
+        for sub_order in child_table_data:
+            order_dict.update(random_row_data)
+            order_dict.update(sub_order)
+            order_data_list.append(order_dict)
+            order_dict = {}
+
+        formatted_orders = self.order_page.match_format_to_sheet_format(order_data_list)
+        self.order_page.download_xslx_sheet()
+        for index in range(len(formatted_orders)):
+            self.info('Comparing the order no {} '.format(formatted_orders[index][0]))
+            values = self.order_page.sheet.iloc[index].values
+            fixed_sheet_row_data = self.reformat_data(values)
+            self.assertCountEqual(fixed_sheet_row_data, formatted_orders[index],
+                                  f"{str(fixed_sheet_row_data)} : {str(formatted_orders[index])}")
+            for item in formatted_orders[index]:
+                self.assertIn(item, fixed_sheet_row_data)
     #
     # @skip('need to be re-implemented to include child table data')
     # def test065_export_order_sheet(self):


### PR DESCRIPTION
```
D:\1lims-automation> nosetests -vs -m test064 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-28 05:43:55.501 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-28 05:43:55.504 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-28 05:43:56.127 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : KhU5YwaOS1D0zXk8HFYPxoLUR3FmrEib_lQjl1tRuzU .....

DevTools listening on ws://127.0.0.1:54137/devtools/browser/8eb9b7fd-747b-4ba4-8f9d-f39301acdeeb
Export order child table ...
2020-09-28 05:44:24.472 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test064_download_suborder_sheet_for_single_order
2020-09-28 05:44:29.767 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 05:44:29.807 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 05:44:30.768 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 05:44:31.700 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-28 05:44:32.394 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 05:44:32.404 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-28 05:44:32.971 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 05:44:32.979 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test064_download_suborder_sheet_for_single_order:2308 - select random order
2020-09-28 05:44:34.693 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-28 05:44:40.722 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:239 - download XSLX sheet
2020-09-28 05:45:11.427 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test064_download_suborder_sheet_for_single_order:2325 - Comparing the order no 1-2020 
2020-09-28 05:45:11.463 | INFO     | ui_testing.testcases.base_test:screen_shot:46 - saved error screen shot : ./screenshots/screenshot_test064_download_suborder_sheet_for_single_order_.png
2020-09-28 05:45:11.837 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-28 05:45:14.711 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
FAIL

======================================================================
FAIL: Export order child table
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test006_orders.py", line 2328, in test064_download_suborder_sheet_for_single_order
    self.assertCountEqual(fixed_sheet_row_data, formatted_orders[index],
AssertionError: Element counts were not equal:
First has 2, Second has 0:  '25.09.2020'
First has 2, Second has 4:  '26.09.2020'
First has 1, Second has 0:  'Not Forwarded'
First has 0, Second has 1:  ''
First has 0, Second has 1:  '0' : ['1-2020', 'firestContact', '25.09.2020', '-', 'firstArticle', '1', '26.09.2020', '26.09.2020', '25.09.2020', 'admin', 'firstTestPlan', '-', '-', '1-2020', 'Raw Material', 'firstT
estUnit', '-', 'Open', '-', 'Not Forwarded', '-', '-'] : ['1-2020', 'firestContact', '26.09.2020', '', '-', 'firstArticle', '1', '26.09.2020', '26.09.2020', '26.09.2020', 'admin', 'firstTestPlan', '0', '-', '-', '
1-2020', 'Raw Material', 'firstTestUnit', '-', 'Open', '-', '-', '-']

----------------------------------------------------------------------
Ran 1 test in 80.099s

FAILED (failures=1)

````