### PR TITLE
LIMS-7727: Orders: Export : check that the fields of "Forwarding" , "Report sent by", "validation date" and "validation by" are displayed in excel sheet

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,37 +5,37 @@
      branches: [ master ]
 
  jobs:
-#   test_pull_request_in_parallel:
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         test_cases: [0]
+   test_pull_request_in_parallel:
+     runs-on: ubuntu-20.04
+     strategy:
+       fail-fast: false
+       matrix:
+         test_cases: [0]
+
+     steps:
+       - uses: actions/checkout@master
+
+       - name: pull docker image
+         run:  docker pull 0xislamtaha/seleniumchromenose:83
+
+       - name: parallel execution for each module
+         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
+
+#  test_pull_request_in_series:
+#    runs-on: ubuntu-20.04
+##    needs: test_pull_request_in_parallel
+#    if: always()
+#    strategy:
+#      fail-fast: false
 #
-#     steps:
-#       - uses: actions/checkout@master
+#    steps:
+#      - uses: actions/checkout@master
 #
-#       - name: pull docker image
-#         run:  docker pull 0xislamtaha/seleniumchromenose:83
+#      - name: pull docker image
+#        run:  docker pull 0xislamtaha/seleniumchromenose:83
 #
-#       - name: parallel execution for each module
-#         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
-
-  test_pull_request_in_series:
-    runs-on: ubuntu-20.04
-#    needs: test_pull_request_in_parallel
-    if: always()
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@master
-
-      - name: pull docker image
-        run:  docker pull 0xislamtaha/seleniumchromenose:83
-
-      - name: sequal execution for series
-        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
+#      - name: sequal execution for series
+#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
 
 #  merge_launches:
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -4,7 +4,7 @@ EXECUTION_FILES=(
      ui_testing/testcases/extended_tests/test001_order.py
   )
 
- TEST_REG='test004'
+ TEST_REG='test005'
 
 
  NODE_TOTAL=$1;

--- a/ui_testing/pages/analysis_page.py
+++ b/ui_testing/pages/analysis_page.py
@@ -74,14 +74,15 @@ class SingleAnalysisPage(AllAnalysesPage):
             records_data.append(temp_record)
         return records_data
 
-    def set_testunit_values(self, lower=0, upper=100):
+    def set_testunit_values(self, lower=0, upper=100, save=True):
         self.open_accordion_for_analysis_index()
         testunit_value_fields = self.base_selenium.find_elements(element='analysis_page:testunits_analysis')
         value = self.generate_random_number(lower=lower, upper=upper)
         for field in testunit_value_fields:
             field.clear()
             field.send_keys(value)
-        self.base_selenium.click(element='general:save')
+        if save:
+            self.base_selenium.click(element='general:save')
 
     def change_validation_options(self, text=''):
         if text:


### PR DESCRIPTION
https://modeso.atlassian.net/browse/LIMS-7727
```
2020-09-28 19:10:52.446 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-28 19:10:52.449 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-28 19:10:53.047 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : tNlxFkjBKzP5cpfIYfhvJtvezYrIpUTBEre09WXvgLw .....

DevTools listening on ws://127.0.0.1:57832/devtools/browser/e26e00e2-1b00-49de-a7ae-fab8c80dfe7f
Orders: Export : check that the fields of "Forwarding" , "Report sent by", "validation date" and [with lang='EN'] ...
2020-09-28 19:11:42.275 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test005_check_new_fields_are_displayed_in_XSLX_0_EN
2020-09-28 19:11:42.287 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-28 19:11:42.930 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 19:11:42.938 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-28 19:11:43.587 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 19:11:46.945 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:11:46.973 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:11:47.686 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:11:48.406 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-28 19:11:49.177 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-28 19:11:49.181 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:266 - edit order with No 7-2020
2020-09-28 19:11:50.625 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:11:51.104 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:11:52.117 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:11:52.839 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-28 19:11:54.248 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:269 - navigate to analysis tab
2020-09-28 19:11:54.869 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:11:55.413 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:11:56.289 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-28 19:12:00.049 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:272 - change validation options to conform
2020-09-28 19:12:09.486 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-28 19:12:13.242 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:12:13.696 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:14.422 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:15.291 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 7-2020
2020-09-28 19:12:16.221 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:12:16.393 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:17.109 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:17.909 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:18.700 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:239 - download XSLX sheet
2020-09-28 19:12:48.995 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:288 - Comparing the downloaded order 
2020-09-28 19:12:48.998 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Forwarding field is displayed in xslx sheet
2020-09-28 19:12:48.999 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Report sent by field is displayed in xslx sheet
2020-09-28 19:12:49.000 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Validation by field is displayed in xslx sheet
2020-09-28 19:12:49.001 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Validation date field is displayed in xslx sheet
2020-09-28 19:12:49.002 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:292 - asserting correct data displayed
2020-09-28 19:12:49.004 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-28 19:12:50.653 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok
Orders: Export : check that the fields of "Forwarding" , "Report sent by", "validation date" and [with lang='DE'] ...
2020-09-28 19:12:50.656 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test005_check_new_fields_are_displayed_in_XSLX_1_DE
2020-09-28 19:12:50.666 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-28 19:12:51.238 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 19:12:51.254 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-28 19:12:51.767 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-28 19:12:53.075 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:12:53.704 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:54.399 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:55.108 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-28 19:12:55.783 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-28 19:12:55.786 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:266 - edit order with No 22-2020
2020-09-28 19:12:57.453 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:12:57.888 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:58.906 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:12:59.621 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-28 19:13:01.026 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:269 - navigate to analysis tab
2020-09-28 19:13:01.163 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:13:01.532 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:02.372 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-28 19:13:05.698 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:272 - change validation options to conform
2020-09-28 19:13:15.147 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-28 19:13:16.860 | INFO     | ui_testing.pages.my_profile_page:get_my_profile_page:12 - Get my profile page.
2020-09-28 19:13:19.257 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:13:19.283 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:19.990 | INFO     | ui_testing.pages.my_profile_page:chang_lang:35 - Change language to DE
2020-09-28 19:13:27.316 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:13:27.335 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:30.732 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:13:31.082 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:31.882 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:32.863 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 22-2020
2020-09-28 19:13:33.782 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:13:34.029 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:34.824 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:35.693 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:13:36.587 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:239 - download XSLX sheet
2020-09-28 19:14:06.908 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:288 - Comparing the downloaded order 
2020-09-28 19:14:06.911 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Versand field is displayed in xslx sheet
2020-09-28 19:14:06.912 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Bericht Versand duch field is displayed in xslx sheet
2020-09-28 19:14:06.915 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Probenfreigabe Datum field is displayed in xslx sheet
2020-09-28 19:14:06.916 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:290 - asserting Probenfreigabe durch field is displayed in xslx sheet
2020-09-28 19:14:06.917 | INFO     | test001_order:test005_check_new_fields_are_displayed_in_XSLX:292 - asserting correct data displayed
2020-09-28 19:14:06.919 | INFO     | ui_testing.pages.my_profile_page:get_my_profile_page:12 - Get my profile page.
2020-09-28 19:14:08.595 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:14:08.619 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:14:09.458 | INFO     | ui_testing.pages.my_profile_page:chang_lang:35 - Change language to EN
2020-09-28 19:14:16.751 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-28 19:14:16.769 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-28 19:14:18.906 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-28 19:14:19.848 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 2 tests in 208.711s

OK

```