### PR TITLE
LIMS-4800 Orders: Test plan Approach: test units pop-up: In case I ha…

### DIFF
--- a/api_testing/apis/article_api.py
+++ b/api_testing/apis/article_api.py
@@ -184,7 +184,7 @@ class ArticleAPI(ArticleAPIFactory):
         self.info("search for article with material type {}".format(material_type))
         for article in articles['articles']:
             if article['materialType'] == material_type:
-                return article['name']
+                return article
 
         self.info("No article with requested material type, So create article")
         materialType = {"id": material_type_id, "text": material_type}
@@ -236,4 +236,3 @@ class ArticleAPI(ArticleAPIFactory):
         with open(config_file, "r") as read_file:
             payload = json.load(read_file)
         super().set_configuration(payload=payload)
-

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3658,3 +3658,19 @@ class OrdersTestCases(BaseTest):
             self.assertFalse(self.order_page.confirm_popup(check_only=True))
             self.info('asserting redirection to active table')
             self.assertEqual(self.order_page.orders_url, self.base_selenium.get_url())
+
+    def test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan(self) :
+            """
+           Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name
+           in one test plan, both of them should display in the test units pop-up.
+
+            LIMS-4800
+            """
+            self.test_plan_api = TestPlanAPI()
+            response, payload = self.test_unit_api.create_qualitative_testunit(name='xxx')
+            response2, payload2 = self.test_unit_api.create_qualitative_testunit(name='xxx')
+            import ipdb;
+            ipdb.set_trace()
+            testplan= self.test_plan_api.create_testplan_from_test_unit_id(test_unit_id=response['testUnit']['testUnitId'])
+
+   

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3667,10 +3667,15 @@ class OrdersTestCases(BaseTest):
             LIMS-4800
             """
             self.test_plan_api = TestPlanAPI()
-            response, payload = self.test_unit_api.create_qualitative_testunit(name='xxx')
-            response2, payload2 = self.test_unit_api.create_qualitative_testunit(name='xxx')
+            tu_name = self.generate_random_string()
+            response, payload = self.test_unit_api.create_qualitative_testunit(name=tu_name)
+            first_tu = self.test_unit_api.get_testunit_form_data(response['testUnit']['testUnitId'])[0]['testUnit']
+            formatted_tu = TstUnit().map_testunit_to_testplan_format(testunit=first_tu)
+            response2, payload2 = self.test_unit_api.create_qualitative_testunit(name=tu_name)
+            second_tu = self.test_unit_api.get_testunit_form_data(response2['testUnit']['testUnitId'])[0]['testUnit']
+            formatted_tu_2 = TstUnit().map_testunit_to_testplan_format(testunit=second_tu)
             import ipdb;
             ipdb.set_trace()
-            testplan= self.test_plan_api.create_testplan_from_test_unit_id(test_unit_id=response['testUnit']['testUnitId'])
+            tp_response, tp_payload = self.test_plan_api.create_testplan(testUnits=[formatted_tu,formatted_tu_2],selectedTestUnits=[formatted_tu,formatted_tu_2])
 
    


### PR DESCRIPTION
```
D:\1lims-automation> nosetests -vs -m test107 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-29 13:06:56.683 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-29 13:06:56.687 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-29 13:06:58.816 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : B8nvPGQGmp2oeZYJeNm0SZ6MlQhpPMgM1tw-5ln-w0U .....

DevTools listening on ws://127.0.0.1:60263/devtools/browser/e9fdc683-6a41-431b-8c90-88ab8c0ff185
Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name ...
2020-09-29 13:09:57.096 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan
2020-09-29 13:10:08.461 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-29 13:10:08.574 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 13:10:09.808 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 13:10:10.787 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-29 13:10:11.451 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-29 13:10:11.461 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-29 13:10:13.431 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-29 13:10:13.440 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-29 13:10:14.151 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:14.161 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-29 13:10:14.581 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
201
2020-09-29 13:10:14.604 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/201
2020-09-29 13:10:14.774 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:14.793 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/materialTypes
2020-09-29 13:10:14.992 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:15.002 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-29 13:10:15.221 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:15.230 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/203
2020-09-29 13:10:15.423 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:15.442 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/articles
2020-09-29 13:10:15.945 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 13:10:15.983 | INFO     | api_testing.apis.article_api:get_formatted_article_with_formatted_material_type:207 - search for article with material type {'id': 1, 'name': 'Raw Material'}
2020-09-29 13:10:16.003 | INFO     | ui_testing.testcases.base_test:screen_shot:46 - saved error screen shot : ./screenshots/screenshot_test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan_.pn
g
2020-09-29 13:10:16.838 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-29 13:10:21.513 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ERROR

======================================================================
ERROR: Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\1lims-automation\ui_testing\testcases\basic_tests\test006_orders.py", line 3674, in test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan
    testplan= self.test_plan_api.create_testplan_from_test_unit_id(test_unit_id=response['testUnit']['testUnitId'])
  File "D:\1lims-automation\api_testing\apis\test_plan_api.py", line 301, in create_testplan_from_test_unit_id
    formatted_article = ArticleAPI().get_formatted_article_with_formatted_material_type(formatted_material)
  File "D:\1lims-automation\api_testing\apis\article_api.py", line 211, in get_formatted_article_with_formatted_material_type
    elif article['materialType'] == material_type['text']:
KeyError: 'text'

----------------------------------------------------------------------
Ran 1 test in 205.073s

```