### PR TITLE
LIMS-6947  Mailing improvement: In export table, field will be displayed "Forwarded/Not forwarded"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,37 +5,37 @@
      branches: [ master ]
 
  jobs:
-#   test_pull_request_in_parallel:
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         test_cases: [0]
+   test_pull_request_in_parallel:
+     runs-on: ubuntu-20.04
+     strategy:
+       fail-fast: false
+       matrix:
+         test_cases: [0]
+
+     steps:
+       - uses: actions/checkout@master
+
+       - name: pull docker image
+         run:  docker pull 0xislamtaha/seleniumchromenose:83
+
+       - name: parallel execution for each module
+         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
+
+#  test_pull_request_in_series:
+#    runs-on: ubuntu-20.04
+##    needs: test_pull_request_in_parallel
+#    if: always()
+#    strategy:
+#      fail-fast: false
 #
-#     steps:
-#       - uses: actions/checkout@master
+#    steps:
+#      - uses: actions/checkout@master
 #
-#       - name: pull docker image
-#         run:  docker pull 0xislamtaha/seleniumchromenose:83
+#      - name: pull docker image
+#        run:  docker pull 0xislamtaha/seleniumchromenose:83
 #
-#       - name: parallel execution for each module
-#         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
-
-  test_pull_request_in_series:
-    runs-on: ubuntu-20.04
-#    needs: test_pull_request_in_parallel
-    if: always()
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@master
-
-      - name: pull docker image
-        run:  docker pull 0xislamtaha/seleniumchromenose:83
-
-      - name: sequal execution for series
-        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
+#      - name: sequal execution for series
+#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
 
 #  merge_launches:
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 EXECUTION_FILES=(
-     ui_testing/testcases/extended_tests/test001_order.py
+     ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test004'
+ TEST_REG='test105'
 
 
  NODE_TOTAL=$1;

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3673,3 +3673,4 @@ class OrdersTestCases(BaseTest):
         self.order_page.download_xslx_sheet()
         data_in_sheet = self.order_page.sheet.iloc[0]
         self.assertIn('Forwarding',data_in_sheet)
+        self.assertIn(data_in_sheet['Forwarding'] , ['Forwarded', 'Not Forwarded'] )

--- a/ui_testing/testcases/basic_tests/test006_orders.py
+++ b/ui_testing/testcases/basic_tests/test006_orders.py
@@ -3658,3 +3658,18 @@ class OrdersTestCases(BaseTest):
             self.assertFalse(self.order_page.confirm_popup(check_only=True))
             self.info('asserting redirection to active table')
             self.assertEqual(self.order_page.orders_url, self.base_selenium.get_url())
+
+    def test105_field_should_be_displayes_in_export_table(self):
+        '''
+        Mailing improvement: In export table, field will be displayed "Forwarded/Not forwarded"
+        LIMS-6947
+        :return:
+        '''
+        random_order = random.choice(self.orders_api.get_all_orders_json())
+        self.info('edit order with No {}'.format(random_order['orderNo']))
+        self.order_page.filter_by_order_no(random_order['orderNo'])
+        row = self.orders_page.result_table()[0]
+        self.info('download excel sheet of order {}'.format(random_order['orderNo']))
+        self.order_page.download_xslx_sheet()
+        data_in_sheet = self.order_page.sheet.iloc[0]
+        self.assertIn('Forwarding',data_in_sheet)


### PR DESCRIPTION
```
C:\Users\omnia\Documents\1lims-app\1lims-automation>nosetests -vs --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py -m test105 --tc-file=config.ini
c:\users\omnia\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named 'fcntl'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-29 17:12:31.675 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-29 17:12:31.680 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-29 17:12:32.856 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : OYqDtUSbSqREJ9xhG1DkLhZFKAYp8hUsaS_MjS2jTGY .....

DevTools listening on ws://127.0.0.1:62258/devtools/browser/5cb4b694-aeea-4bbf-bf91-0e4fd349fbcd
Mailing improvement: In export table, field will be displayed "Forwarded/Not forwarded" ...
2020-09-29 17:14:05.772 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test105_field_should_be_displayes_in_export_table
2020-09-29 17:14:10.298 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-29 17:14:11.199 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 17:14:12.077 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 17:14:12.880 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-29 17:14:14.095 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-29 17:14:14.104 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-29 17:14:15.245 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-29 17:14:15.256 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/orders
2020-09-29 17:14:16.317 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-29 17:14:16.326 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test105_field_should_be_displayes_in_export_table:3669 - edit order with No 82-2020
2020-09-29 17:14:16.574 | INFO     | ui_testing.pages.orders_page:filter_by_order_no:138 - Filter by order no. : 82-2020
2020-09-29 17:14:17.591 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-29 17:14:17.765 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 17:14:18.656 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 17:14:19.613 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-29 17:14:20.513 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test105_field_should_be_displayes_in_export_table:3672 - download excel sheet of order 82-2020
2020-09-29 17:14:20.515 | INFO     | ui_testing.pages.base_pages:download_xslx_sheet:239 - download XSLX sheet
2020-09-29 17:14:50.997 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-29 17:14:53.784 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 142.916s

OK

```