### PR TITLE
Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name in one test plan, both of them should display in the test units pop-up

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,37 +5,37 @@
      branches: [ master ]
 
  jobs:
-#   test_pull_request_in_parallel:
-#     runs-on: ubuntu-20.04
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         test_cases: [0]
+   test_pull_request_in_parallel:
+     runs-on: ubuntu-20.04
+     strategy:
+       fail-fast: false
+       matrix:
+         test_cases: [0]
+
+     steps:
+       - uses: actions/checkout@master
+
+       - name: pull docker image
+         run:  docker pull 0xislamtaha/seleniumchromenose:83
+
+       - name: parallel execution for each module
+         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
 #
-#     steps:
-#       - uses: actions/checkout@master
+#  test_pull_request_in_series:
+#    runs-on: ubuntu-20.04
+##    needs: test_pull_request_in_parallel
+#    if: always()
+#    strategy:
+#      fail-fast: false
 #
-#       - name: pull docker image
-#         run:  docker pull 0xislamtaha/seleniumchromenose:83
+#    steps:
+#      - uses: actions/checkout@master
 #
-#       - name: parallel execution for each module
-#         run: timeout 2h bash .github/workflows/execution.sh ${{ strategy.job-total }} ${{ matrix.test_cases }} ${{ github.ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'not series' ${{ secrets.UUID }}
-
-  test_pull_request_in_series:
-    runs-on: ubuntu-20.04
-#    needs: test_pull_request_in_parallel
-    if: always()
-    strategy:
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@master
-
-      - name: pull docker image
-        run:  docker pull 0xislamtaha/seleniumchromenose:83
-
-      - name: sequal execution for series
-        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
+#      - name: pull docker image
+#        run:  docker pull 0xislamtaha/seleniumchromenose:83
+#
+#      - name: sequal execution for series
+#        run: timeout 1h bash .github/workflows/execution.sh 1 1 ${{ github.head_ref }} ${{ github.run_id }} ${{ github.run_number }} $(pwd) 'series' ${{ secrets.UUID }}
 
 #  merge_launches:
 #    runs-on: ubuntu-20.04

--- a/.github/workflows/execution.sh
+++ b/.github/workflows/execution.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 EXECUTION_FILES=(
-     ui_testing/testcases/extended_tests/test001_order.py
+     ui_testing/testcases/basic_tests/test006_orders.py
   )
 
- TEST_REG='test004'
+ TEST_REG='test107'
 
 
  NODE_TOTAL=$1;


### PR DESCRIPTION
```
D:\1lims-automation> nosetests -vs -m test107 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-30 01:26:53.202 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-30 01:26:53.203 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-30 01:26:54.066 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : l-uWW73Pyrkhez264yy0wwPX7Tc4gszJmxexrFisb-c .....

DevTools listening on ws://127.0.0.1:51853/devtools/browser/9720cb3d-3194-491d-a5cd-af240b39dcb1
Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name ...
2020-09-30 01:27:27.200 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan
2020-09-30 01:27:30.091 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:27:30.515 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:27:31.402 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:27:32.200 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-30 01:27:32.893 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:27:32.902 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-30 01:27:33.506 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:27:33.516 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:27:34.145 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:27:34.154 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/356
2020-09-30 01:27:34.324 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:27:34.333 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:27:34.536 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:27:34.555 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/357
2020-09-30 01:27:34.701 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:27:34.710 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-30 01:27:34.944 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:27:34.972 | INFO     | ui_testing.pages.order_page:create_new_order:141 -  Create new order.
2020-09-30 01:27:34.987 | INFO     | ui_testing.pages.orders_page:click_create_order_button:23 - Press create order button
2020-09-30 01:27:35.797 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:27:43.537 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:27:45.139 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:27:46.759 | INFO     | ui_testing.pages.order_page:set_new_order:19 - Set new order.
2020-09-30 01:27:54.371 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:01.752 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:09.164 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:18.406 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:26.059 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:36.164 | INFO     | ui_testing.pages.base_pages:save:55 - save the changes
2020-09-30 01:28:36.166 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:28:37.100 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:28:38.726 | INFO     | ui_testing.pages.order_page:create_new_order:177 -  Order created with no : 127-2020 
2020-09-30 01:28:39.051 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:28:40.736 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-30 01:28:51.290 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:28:51.837 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:28:52.835 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
[{'Test Unit Name': 'a007138eb0 () V: 1', 'Category': '7c73463895', 'Value': '', 'Colonies': 'N/A', 'Specifications': 'b1c7d87a2e', 'Volume': 'N/A', 'Result': 'Open ( )', 'Remarks': 'Select Option'}, {'Test Unit N
ame': 'a007138eb0 () V: 1', 'Category': 'a24e7192e7', 'Value': '', 'Colonies': 'N/A', 'Specifications': '9390fbacd2', 'Volume': 'N/A', 'Result': 'Open ( )', 'Remarks': 'Select Option'}]
a007138eb0
2020-09-30 01:28:57.069 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-30 01:28:58.741 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 126.444s

OK

D:\1lims-automation> nosetests -vs -m test107 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-30 01:35:10.926 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-30 01:35:10.931 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-30 01:35:11.690 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : pRgYr7o3jqk8VBNl0cZhMzXJANhssE47zJw2KWUK3uk .....

DevTools listening on ws://127.0.0.1:52184/devtools/browser/1b5d68d0-7f0b-4d2d-a9fc-b9157ee5ec85
Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name ...
2020-09-30 01:35:40.003 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan
2020-09-30 01:35:44.660 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:35:44.692 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:35:45.509 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:35:46.337 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-30 01:35:47.025 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:35:47.033 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-30 01:35:47.810 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:35:47.819 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:35:48.966 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:35:48.974 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/358
2020-09-30 01:35:49.204 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:35:49.213 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:35:49.422 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:35:49.426 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/359
2020-09-30 01:35:49.591 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:35:49.599 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-30 01:35:49.841 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:35:49.850 | INFO     | ui_testing.pages.order_page:create_new_order:141 -  Create new order.
2020-09-30 01:35:49.858 | INFO     | ui_testing.pages.orders_page:click_create_order_button:23 - Press create order button
2020-09-30 01:35:50.220 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:35:58.215 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:35:59.854 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:01.487 | INFO     | ui_testing.pages.order_page:set_new_order:19 - Set new order.
2020-09-30 01:36:09.089 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:16.767 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:23.865 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:32.981 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:40.357 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:50.343 | INFO     | ui_testing.pages.base_pages:save:55 - save the changes
2020-09-30 01:36:50.345 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:36:51.177 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:36:52.926 | INFO     | ui_testing.pages.order_page:create_new_order:177 -  Order created with no : 128-2020 
2020-09-30 01:36:53.224 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:36:54.907 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-30 01:37:05.638 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:37:05.961 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:37:06.953 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
42fc52db1c
42fc52db1c
2020-09-30 01:37:11.418 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-30 01:37:12.886 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 122.466s

OK

D:\1lims-automation> nosetests -vs -m test107 --logging-level=WARNING ui_testing/testcases/basic_tests/test006_orders.py --tc-file=config.ini
c:\users\lenovo\appdata\local\programs\python\python38-32\lib\site-packages\nose\plugins\manager.py:394: RuntimeWarning: Unable to load plugin noseprogressive = noseprogressive:ProgressivePlugin: No module named '
_curses'
  warn("Unable to load plugin %s: %s" % (ep, e),
2020-09-30 01:39:37.472 | INFO     | api_testing.apis.base_api:_get_authorized_session:46 - Get authorized api session.
2020-09-30 01:39:37.474 | INFO     | api_testing.apis.base_api:_get_authorized_session:47 - admin:admin
2020-09-30 01:39:38.374 | INFO     | api_testing.apis.base_api:_get_authorized_session:58 - session ID : P_3I1Ko1cj3nfeAy63HXimOjjviNzGW8sxYzn2h04Qw .....

DevTools listening on ws://127.0.0.1:52399/devtools/browser/ce41d338-2166-4df8-931b-85b538b0cc5d
Orders: Test plan Approach: test units pop-up: In case I have two test units with the same name ...
2020-09-30 01:40:08.153 | INFO     | ui_testing.testcases.base_test:setUp:27 - Test case : test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan
2020-09-30 01:40:11.404 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:40:11.434 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:40:12.286 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:40:13.176 | INFO     | api_testing.apis.test_unit_api:set_name_configuration_name_only:437 - set test unit configuration
2020-09-30 01:40:13.867 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:40:13.876 | INFO     | api_testing.apis.orders_api:set_configuration:498 - set order configuration
2020-09-30 01:40:14.522 | INFO     | api_testing.apis.base_api:set_configuration:73 - status code: 1
2020-09-30 01:40:14.548 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:40:15.187 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:40:15.214 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/360
2020-09-30 01:40:15.372 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:40:15.376 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits
2020-09-30 01:40:15.572 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:40:15.581 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testUnits/get/361
2020-09-30 01:40:15.773 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:40:15.783 | INFO     | api_testing.apis.base_api:wrapper:130 - GET : https://automation.1lims.com/api/testPlans
2020-09-30 01:40:16.017 | DEBUG    | api_testing.apis.base_api:wrapper:137 - status code: 1
2020-09-30 01:40:16.028 | INFO     | ui_testing.pages.order_page:create_new_order:141 -  Create new order.
2020-09-30 01:40:16.046 | INFO     | ui_testing.pages.orders_page:click_create_order_button:23 - Press create order button
2020-09-30 01:40:16.380 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:40:24.445 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:40:26.091 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:40:27.696 | INFO     | ui_testing.pages.order_page:set_new_order:19 - Set new order.
2020-09-30 01:40:35.206 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:40:42.780 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:40:49.952 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:40:59.201 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:41:06.814 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:41:16.873 | INFO     | ui_testing.pages.base_pages:save:55 - save the changes
2020-09-30 01:41:16.875 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:17.841 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:19.674 | INFO     | ui_testing.pages.order_page:create_new_order:177 -  Order created with no : 129-2020 
2020-09-30 01:41:19.958 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:41:21.549 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-30 01:41:31.805 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan:3686 - checking that both testunits with same name app
ear in the analysis form
2020-09-30 01:41:32.226 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:41:32.599 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:33.623 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-30 01:41:38.088 | INFO     | ui_testing.testcases.basic_tests.test006_orders:test107_check_that_two_testunits_with_same_name_displayed_in_one_testplan:3694 - checking that both testunits with same name app
ear in the analysis table
2020-09-30 01:41:39.670 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:41:40.079 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:40.882 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:42.032 | DEBUG    | ui_testing.pages.base_pages:sleep_small:43 - wait up to 1 sec
2020-09-30 01:41:44.508 | INFO     | ui_testing.pages.analyses_page:filter_by_order_no:22 - Filter by order number : 129-2020
2020-09-30 01:41:44.515 | INFO     | ui_testing.pages.base_pages:open_filter_menu:93 - open Filter
2020-09-30 01:41:53.298 | INFO     | ui_testing.pages.base_pages:wait_until_page_is_loaded:606 - wait until page is loaded
2020-09-30 01:41:53.471 | DEBUG    | ui_testing.pages.base_pages:sleep_tiny:39 - wait up to 0.5 sec
2020-09-30 01:41:54.297 | DEBUG    | ui_testing.pages.base_pages:sleep_medium:47 - wait up to 2 sec
2020-09-30 01:41:58.057 | INFO     | ui_testing.testcases.base_test:tearDown:33 - go to dashboard page
2020-09-30 01:41:59.747 | INFO     | ui_testing.testcases.base_test:tearDown:35 - TearDown.     
ok

----------------------------------------------------------------------
Ran 1 test in 143.142s

OK
```